### PR TITLE
Note that fast nodes can never revert to full node

### DIFF
--- a/docs/BSC-fast-node.md
+++ b/docs/BSC-fast-node.md
@@ -5,6 +5,11 @@ sidebar_position: 2
 ---
 # How to Run A Fast Node on BNB Smart Chain
 
+## Note
+**Fast Node does not generate Trie Data when syncing.  
+Once the Fast Node is running, there is no way to switch back to Full Node.  
+Need to re-download snapshot data to restore it to Full Node.**
+
 ## Fast Node Functions
 
 * Stores the full blockchain history on disk and can answer the data request from the network.

--- a/docs/BSC-separate-node.md
+++ b/docs/BSC-separate-node.md
@@ -36,6 +36,8 @@ If the fast node runs in not local mode, the node will disable diff protocol by 
 
 ` ./geth --config ./config.toml --datadir ./node --syncmode full --cache 5000 --tries-verify-mode none`
 
+***Note: fast node can never revert to full node.**
+
 #### Verify node
 When a full node has enabled the trust protocol, it can serve as a verify node, at the same time, we will recommend you to enable persist diff, disable snap protocol and diff protocol when running a verify node.
 


### PR DESCRIPTION
#### Description
Update `docs/BSC-fast-node.md` and `docs/BSC-separate-node.md` to note that fast nodes can never revert to full node.