### PR TITLE
'3rd Party Provider' UPDATE

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -77,6 +77,9 @@ The rate limit of BSC endpoint on Testnet and Mainnet is 8K/5min.
   
 * [BlockVision](https://docs.blockvision.org/blockvision/): <https://docs.blockvision.org/blockvision/chain-apis/bnb-chain-api>
 
+* [NOWNodes](https://nownodes.io/): <https://nownodes.io/nodes/binance-smart-chain>
+
+
 
 ## Start HTTP JSON-RPC
 


### PR DESCRIPTION
Hi Binance Team!
I added NOWNodes to the providers list.

NOWNodes is a blockchain-as-a-service solution that lets users get access to full Nodes and blockbook Explorers via API. Instant access to 56 blockchain networks, including BTC, ETH, and BSC, which have over 1000 coins and tokens.

Please, accept my request 
Thank you! :)