### PR TITLE
node: remove diffsync flag

### DIFF
--- a/docs/BSC-FAQs-validator.md
+++ b/docs/BSC-FAQs-validator.md
@@ -152,7 +152,7 @@ This error occurs due to data corruption. You can run geth snapshot verify-state
 ### What to do if Sync is slow on running the following command 
 
 ~~~~
-*_start order: geth --config ./config.toml --datadir /data/server/data-seed/ --cache 20000 --rpc.allow-unprotected-txs --syncmode snap –diffsync --txlookuplimit 0_*
+*_start order: geth --config ./config.toml --datadir /data/server/data-seed/ --cache 20000 --rpc.allow-unprotected-txs --syncmode snap  --txlookuplimit 0_*
 ~~~~
 
 Try pruning the state -- stop geth, then run geth --datadir=node - prune-state. Assuming that datadir is node, change that if it's elsewhere then restart after it's done. Follow https://github.com/bnb-chain/bsc/issues/502 to get more tips about how to maintain a synced node.
@@ -189,7 +189,7 @@ The two biggest bottlenecks are CPU and IOPS when syncing. Steps are as follows:
 [Optional] Create a service or use screen to run the command below, so it doesn't stop if you are using SSH.
 Run screen then press enter, anytime you lose connection via ssh, run screen -r to get back the "screen/terminal" where geth was running Geth Command 
 
-`geth --config ./config.toml –datadir ./mainnet --cache 100000 --rpc.allow-unprotected-txs --txlookuplimit 0 --http --maxpeers 100 –ws --syncmode=full --snapshot=false –diffsync`
+`geth --config ./config.toml –datadir ./mainnet --cache 100000 --rpc.allow-unprotected-txs --txlookuplimit 0 --http --maxpeers 100 –ws --syncmode=full --snapshot=false `
 
 ### What are the few adjustments that can help resolve sync issues?
 

--- a/docs/BSC-verify-node.md
+++ b/docs/BSC-verify-node.md
@@ -57,7 +57,7 @@ Your --datadir flag should point to the extracted chaindata folder path
 
 4. Start a full node
 ```
-geth --config ./config.toml --datadir ./node --diffsync --cache 8000 --rpc.allow-unprotected-txs --txlookuplimit 0
+geth --config ./config.toml --datadir ./node --cache 8000 --rpc.allow-unprotected-txs --txlookuplimit 0
 ```
 
 :::note

--- a/docs/validator/fullnode.md
+++ b/docs/validator/fullnode.md
@@ -80,7 +80,7 @@ Your --datadir flag should point to the extracted chaindata folder path
 
 4. Start a full node
 ```
-./geth --config ./config.toml --datadir ./node --diffsync --cache 8000 --rpc.allow-unprotected-txs --txlookuplimit 0
+./geth --config ./config.toml --datadir ./node  --cache 8000 --rpc.allow-unprotected-txs --txlookuplimit 0
 ```
 :::note
 Make sure you use the version of geth you downloaded with wget above, and not your local installation of geth, which might be the wrong version.

--- a/docs/validator/node-maintenance.md
+++ b/docs/validator/node-maintenance.md
@@ -47,10 +47,6 @@ How to prune:
 
 `block-amount-reserved` is the number of ancient data blocks that you want to keep after pruning. 
 
-
-### Diff Sync
-Diff sync allows a BSC client to simply apply the execution result of a block securely without executing the transactions. Diff sync improves the syncing speed by 60%～70% approximately according to the tests. All full nodes are suggested to enable it by adding `--diffsync` in the starting command. This flag is ignored when used with `--tries-verify-mode none` on Fast nodes.
-
 ### Light Storage
 When the node crashes or been force killed, the node will sync from a block that was a few minutes or a few hours ago. This is because the state in memory is not persisted into the database in real time, and the node needs to replay blocks from the last checkpoint once it start. The replaying time depends on the configuration `TrieTimeout` in the config.toml.  We suggest you raise it if you can tolerate with long replaying time, so the node can keep light storage.
 

--- a/docs/validator/upgrade-fullnode.md
+++ b/docs/validator/upgrade-fullnode.md
@@ -51,5 +51,5 @@ Make sure to use the same start-up command you used before the upgrade. So in th
 
 ```bash
 ##
-./geth --config ./config.toml --datadir ./node --diffsync --cache 8000 --rpc.allow-unprotected-txs --txlookuplimit 0
+./geth --config ./config.toml --datadir ./node --cache 8000 --rpc.allow-unprotected-txs --txlookuplimit 0
 ```


### PR DESCRIPTION
The diff sync mode is deprecated because BSC supports fastnode mode which is more efficient, so let us remove it from the document.