### PR TITLE
docs: remove link to unready features

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -302,16 +302,12 @@ const sidebars = {
           {
             type: 'category',
             collapsed: true,
-            label: 'ZkBNB', 
-            items:['zkbnb/zkbnb-overview','zkbnb/zkbnb-architecture','zkbnb/zkbnb-storageLayout',
-                   'zkbnb/zkbnb-tokenomics','zkbnb/zkbnb-wallets'],
+            label: 'ZkBNB',
+              items:['zkbnb/zkbnb-overview','zkbnb/zkbnb-architecture', 'zkbnb/zkbnb-tokenomics'],
           },
           
     ],
     },
-
-
-
     {
       type: 'category',
       collapsed: true,


### PR DESCRIPTION
### Description
This pr remove the docs for unready feature of zkBNB

### Example
No

### Changes
- The storage layout docs are not good.
- The EIP721 signature for ZkBNB is not ready yet.
