### PR TITLE
docs: update spec for running bc validators

### DIFF
--- a/docs/beaconchain/validator/run-val.md
+++ b/docs/beaconchain/validator/run-val.md
@@ -9,7 +9,8 @@ hide_table_of_contents: false
 
 * VPS running recent versions of Mac OS X or Linux.
 * 2 TB of free disk space, accessible at a minimum read/write speed of 200 MB/s.
-* 16 cores of CPU and 32 gigabytes of memory (RAM).
+* 8 cores of CPU and 16 gigabytes of memory (RAM).
+* Suggest m5.2xlarge instance type on AWS, or c2-standard-8 on Google cloud.
 * A broadband Internet connection with upload/download speeds of at least 10 megabyte per second.
 
 ## Setting up Validator Node


### PR DESCRIPTION
### Description
This pr updates the spec for running beacon chain validators. 
The previous requirement in the docs is too high.

### Example
No

### Changes
-  update spec for running bc valdiators