### PR TITLE
Update fullnode.md - wrong source folder in the `mv` command

### DIFF
--- a/docs/validator/fullnode.md
+++ b/docs/validator/fullnode.md
@@ -59,7 +59,7 @@ In our case, we created a new folder named node, and we moved the extracted snap
 
 ```
 mv server/data-seed/geth/chaindata node/geth/chaindata
-mv server/data-seed/geth/chaindata node/geth/triecache
+mv server/data-seed/geth/triecache node/geth/triecache
 ```
 
 :::


### PR DESCRIPTION
The source folder of the below command should be `server/data-seed/geth/triecache` instead of `server/data-seed/geth/chaindata`:

`mv server/data-seed/geth/chaindata node/geth/triecache`


Reference:
https://github.com/bnb-chain/bsc-snapshots/blob/main/README.md?plain=1#L102