### PR TITLE
fix: add description for new flag `bls-wallet` about side vote addr

### DIFF
--- a/docs/beaconchain/learn/bc-staking.md
+++ b/docs/beaconchain/learn/bc-staking.md
@@ -107,7 +107,8 @@ Please download `tbnbcli` binary from [here](https://github.com/bnb-chain/node/r
 | --commission-max-change-rate | 3000000   (0.03 or 3%)               | The maximum commission  change rate percentage (per day). You can not update this rate.     | Yes          |
 | --side-chain-id              | chapel                               | chain-id of the side  chain the validator belongs to         | Yes          |
 | --side-cons-addr             | 0x1234abcd                           | consensus address of the  validator on side chain, please use hex format prefixed with 0x | Yes          |
-| --side-vote-addr | 0x1234abcd | vote pub key of the validator on side chain, please use hex format prefixed with 0x, supported after BEP126 | Yes |
+| --side-vote-addr | 0x1234abcd | vote pub key of the validator on side chain, please use hex format prefixed with 0x | Yes |
+| --bls-wallet |    /path/to/bls/wallet     |absolute path of BLS wallet| Yes |
 | --side-fee-addr              | 0xabcd1234                           | address that validator  collects fee rewards on side chain, please use hex format prefixed with 0x. | Yes          |
 | --home                       | /path/to/cli_home                    | home directory of bnbcli  data and config, default to “~/.bnbcli” | No           |
 
@@ -231,7 +232,8 @@ Verify your transaction in [mainnet-explorer](https://explorer.binance.org/) or 
 | --website          | www.example.com                  | optional website (default  "[do-not-modify]")                | No           |
 | --details          | some details                     | optional details (default  "[do-not-modify]")                | No           |
 | --commission-rate  | 80000000(that means 0.8  or 80%) | The new commission rate  percentage                          | No           |
-| --side-vote-addr | 0x1234abcd | vote pub key of the validator on side chain, please use hex format prefixed with 0x, supported after BEP126 | Yes |
+| --side-vote-addr | 0x1234abcd | vote pub key of the validator on side chain, please use hex format prefixed with 0x | No |
+| --bls-wallet |    /path/to/bls/wallet     |absolute path of BLS wallet, should be provided if the side vote address is provided| No |
 | --side-fee-addr    | 0xabcd1234                       | address that validator  collects fee rewards on side chain, please use hex format prefixed with 0x. | No           |
 
 
@@ -241,13 +243,13 @@ Verify your transaction in [mainnet-explorer](https://explorer.binance.org/) or 
 * Mainnet
 
 ```bash
-bnbcli staking bsc-edit-validator --chain-id Binance-Chain-Tigris --side-chain-id bsc --moniker bsc_v1_new --from bnb1tfh30c67mkzfz06as2hk0756mgdx8mgypu7ajl --side-vote-addr 0x85e6972fc98cd3c81d64d40e325acfed44365b97a7567a27939c14dbc7512ddcf54cb1284eb637cfa308ae4e00cb5588 --home ~/home_cli
+bnbcli staking bsc-edit-validator --chain-id Binance-Chain-Tigris --side-chain-id bsc --moniker bsc_v1_new --from bnb1tfh30c67mkzfz06as2hk0756mgdx8mgypu7ajl --side-vote-addr 0x85e6972fc98cd3c81d64d40e325acfed44365b97a7567a27939c14dbc7512ddcf54cb1284eb637cfa308ae4e00cb5588 --bls-wallet /home/bls/wallet --home ~/home_cli
 ```
 
 * Testnet
 
 ```bash
-tbnbcli staking bsc-edit-validator --chain-id Binance-Chain-Ganges --side-chain-id chapel --moniker bsc_v1_new --from bnb1tfh30c67mkzfz06as2hk0756mgdx8mgypu7ajl --side-vote-addr 0x85e6972fc98cd3c81d64d40e325acfed44365b97a7567a27939c14dbc7512ddcf54cb1284eb637cfa308ae4e00cb5588 --home ~/home_cli
+tbnbcli staking bsc-edit-validator --chain-id Binance-Chain-Ganges --side-chain-id chapel --moniker bsc_v1_new --from bnb1tfh30c67mkzfz06as2hk0756mgdx8mgypu7ajl --side-vote-addr 0x85e6972fc98cd3c81d64d40e325acfed44365b97a7567a27939c14dbc7512ddcf54cb1284eb637cfa308ae4e00cb5588 --bls-wallet /home/bls/wallet --home ~/home_cli
 ```
 
 

--- a/docs/stake/cli-commands.md
+++ b/docs/stake/cli-commands.md
@@ -28,7 +28,8 @@ Please download `tbnbcli` binary from [here](https://github.com/bnb-chain/node/r
 | --commission-max-change-rate | 3000000   (0.03 or 3%)               | The maximum commission  change rate percentage (per day). You can not update this rate.     | Yes          |
 | --side-chain-id              | chapel                               | chain-id of the side  chain the validator belongs to         | Yes          |
 | --side-cons-addr             | 0x1234abcd                           | consensus address of the  validator on side chain, please use hex format prefixed with 0x | Yes          |
-| --side-vote-addr | 0x1234abcd | vote pub key of the validator on side chain, please use hex format prefixed with 0x, supported after BEP126 | Yes |
+| --side-vote-addr | 0x1234abcd | vote pub key of the validator on side chain, please use hex format prefixed with 0x | Yes |
+| --bls-wallet |    /path/to/bls/wallet     |absolute path of BLS wallet| Yes |
 | --side-fee-addr              | 0xabcd1234                           | address that validator  collects fee rewards on side chain, please use hex format prefixed with 0x. | Yes          |
 | --home                       | /path/to/cli_home                    | home directory of bnbcli  data and config, default to “~/.bnbcli” | No           |
 
@@ -140,7 +141,8 @@ Verify your transaction in [mainnet-explorer](https://explorer.binance.org/) or 
 | --website          | www.example.com                  | optional website (default  "[do-not-modify]")                | No           |
 | --details          | some details                     | optional details (default  "[do-not-modify]")                | No           |
 | --commission-rate  | 80000000(that means 0.8  or 80%) | The new commission rate  percentage                          | No           |
-| --side-vote-addr | 0x1234abcd | vote pub key of the validator on side chain, please use hex format prefixed with 0x, supported after BEP126 | Yes |
+| --side-vote-addr | 0x1234abcd | vote pub key of the validator on side chain, please use hex format prefixed with 0x | No |
+| --bls-wallet |    /path/to/bls/wallet     |absolute path of BLS wallet, should be provided if the side vote address is provided| No |
 | --side-fee-addr    | 0xabcd1234                       | address that validator  collects fee rewards on side chain, please use hex format prefixed with 0x. | No           |
 
 
@@ -148,10 +150,10 @@ Verify your transaction in [mainnet-explorer](https://explorer.binance.org/) or 
 
 ```bash
 ## mainnet
-bnbcli staking bsc-edit-validator --chain-id Binance-Chain-Tigris --side-chain-id bsc --moniker bsc_v1_new --from bnb1tfh30c67mkzfz06as2hk0756mgdx8mgypu7ajl --side-vote-addr 0x85e6972fc98cd3c81d64d40e325acfed44365b97a7567a27939c14dbc7512ddcf54cb1284eb637cfa308ae4e00cb5588 --home ~/home_cli
+bnbcli staking bsc-edit-validator --chain-id Binance-Chain-Tigris --side-chain-id bsc --moniker bsc_v1_new --from bnb1tfh30c67mkzfz06as2hk0756mgdx8mgypu7ajl --side-vote-addr 0x85e6972fc98cd3c81d64d40e325acfed44365b97a7567a27939c14dbc7512ddcf54cb1284eb637cfa308ae4e00cb5588 --bls-wallet /home/bls/wallet --home ~/home_cli 
 
 ##testnet
-bash tbnbcli staking bsc-edit-validator --chain-id Binance-Chain-Ganges --side-chain-id chapel --moniker bsc_v1_new --from bnb1tfh30c67mkzfz06as2hk0756mgdx8mgypu7ajl --side-vote-addr 0x85e6972fc98cd3c81d64d40e325acfed44365b97a7567a27939c14dbc7512ddcf54cb1284eb637cfa308ae4e00cb5588 --home ~/home_cli
+bash tbnbcli staking bsc-edit-validator --chain-id Binance-Chain-Ganges --side-chain-id chapel --moniker bsc_v1_new --from bnb1tfh30c67mkzfz06as2hk0756mgdx8mgypu7ajl --side-vote-addr 0x85e6972fc98cd3c81d64d40e325acfed44365b97a7567a27939c14dbc7512ddcf54cb1284eb637cfa308ae4e00cb5588 --bls-wallet /home/bls/wallet --home ~/home_cli
 ```
 
 ## Delegate BNB

--- a/docs/validator/create-val.md
+++ b/docs/validator/create-val.md
@@ -46,6 +46,7 @@ Use **bnbcli** to create an account or recover an account, make sure the account
 bnbcli staking bsc-create-validator \
 --side-cons-addr {mining account} \
 --side-vote-addr {validator vote pub key} \
+--bls-wallet {path to bls wallet} \
 --side-fee-addr {wallet address on BSC} \
 --address-delegator {wallet address on BC} \
 --side-chain-id bsc \
@@ -65,6 +66,7 @@ bnbcli staking bsc-create-validator \
 tbnbcli staking bsc-create-validator \
 --side-cons-addr {mining account} \
 --side-vote-addr {validator vote pub key} \
+--bls-wallet {path to bls wallet} \
 --side-fee-addr {wallet address on BSC} \
 --address-delegator {wallet address on BC} \
 --side-chain-id chapel \


### PR DESCRIPTION
### Description
add description for new flag `bls-wallet` about side vote addr

### Rationale

### Example

### Changes
side-vote-addr is optional for bsc-edit-validator