### PR TITLE
Add tokenview BSC RPC Node to  wallets-rpc

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -54,6 +54,8 @@ You could find more endpoints from **[here](https://chainlist.org/chain/56)**.
 * **QuickNode:** <https://quicknode.com>
   
 * **BlockVision:** <https://docs.blockvision.org/blockvision/chain-apis/bnb-chain-api>
+  
+* **Tokenview:** <https://services.tokenview.io>
 
 ### Starting HTTP JSON-RPC
 


### PR DESCRIPTION
Hi there, 
I came across your developer resource listing for BNB chain and found that Tokenview is not listed there. I take this opportunity to bring to your attention that Tokenview has been one of the most popular no code web3 platforms for developers and has been providing BSC RPC node services. Hereby, I'd like to request that please add Tokenview BSC Node service to your Thrid-Party RPC Providers. Tokenview not only support BNB chain RPC Node but also BSC blockchain explorer (bsc.tokenview.io) and Archive BSC API. We believe that Tokenview would be a great resource for developers looking to quickly and easily deploy their decentralized applications to the cloud on BNB chain. Thank you for your time and consideration.