### PR TITLE
Update wallets.md to include NOW Wallet

### DIFF
--- a/docs/beaconchain/wallets.md
+++ b/docs/beaconchain/wallets.md
@@ -30,3 +30,5 @@
 | 24     | Infinity Wallet (Desktop Wallet) | <https://infinitywallet.io/>     |Yes  | No|Yes|
 | 25     | BitKeep Wallet (App & Chrome)    | <https://bitkeep.com/> |Yes|No| Yes|
 | 26     | imToken (App)  | <https://token.im> |Yes|Yes| Yes|
+| 27     | NOW Wallet  | <https://walletnow.app> |Yes|Yes| Yes|
+


### PR DESCRIPTION
NOW Wallet is a versatile non-custodial wallet allowing users to buy, exchange, store, and stake 500+ crypto assets on 40+ blockchains, including BNB Beacon Chain (BEP2).