### PR TITLE
Update Wallet.md including NOW Wallet

### DIFF
--- a/docs/Wallet.md
+++ b/docs/Wallet.md
@@ -42,3 +42,5 @@ If you want to be able to receive BNB and other supported tokens on the BNB Smar
 |16     | Guarda Wallet |<https://guarda.com/coins/binance-coin-wallet/>|No|
 |17     | Rabby Wallet |<https://rabby.io/>|No|
 |18     | Atomic Wallet | <https://atomicwallet.io/> | Yes |
+|19     | NOW Wallet | <https://walletnow.app/> | Yes |
+


### PR DESCRIPTION
NOW Wallet is a versatile non-custodial wallet allowing users to buy, exchange, store, and stake 500+ crypto assets on 40+ blockchains, including BNB Chain (BEP20).