### PR TITLE
Update sidebars.js to add link to Upgrades scheduled for 2023

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -306,7 +306,13 @@ const sidebars = {
       type: 'category',
       collapsed: true,
       label: 'Future Developments',
-      items:['dev-outlook-2022', 'dev-outlook/scaling',
+      items:[
+             {
+              type: 'link',
+              label: 'Upgrades for 2023',
+              href: 'https://forum.bnbchain.org/t/bnb-chain-upgrades-mainnet/936#year-of-2023-3',
+             },
+            'dev-outlook/scaling',
              {
               type: 'link',
               label: 'State Expiry',


### PR DESCRIPTION
Updated the sidebar menu for future developments to include the official forum link to the upgrades scheduled for mainnet for the year 2023