### PR TITLE
Add DRPC to Thrid-Party RPC Providers

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -55,6 +55,8 @@ You could find more endpoints from **[here](https://chainlist.org/chain/56)**.
   
 * **BlockVision:** <https://docs.blockvision.org/blockvision/chain-apis/bnb-chain-api>
 
+* **DRPC:** <https://drpc.org/public-endpoints/bsc>
+
 ### Starting HTTP JSON-RPC
 
 You can start the HTTP JSON-RPC with the --http flag


### PR DESCRIPTION
DRPC is a decentralized network of RPC providers. - https://drpc.org/ 
Privacy policy - https://drpc.org/privacy-policy