### PR TITLE
Request for add Zeeve

### DIFF
--- a/docs/learn/ecosystem.md
+++ b/docs/learn/ecosystem.md
@@ -41,7 +41,7 @@ In the below sections you can find a list of different layers of the BSC Stack.
 ### Infrastructure
 | **Components** | **Existing Projects** | **Potentially Interesting Projects**
 |-|-|-
-| **API/Node Access** | [Nodereal](https://nodereal.io/), [Ankr](https://www.ankr.com/), [Chainstack](https://chainstack.com/build-better-with-binance-smart-chain/), [NowNodes](https://nownodes.io/blog/binance-smart-chain-an-introduction), [QuickNode](https://www.quicknode.com/), [Covalent](https://www.covalenthq.com/), [Infstones](https://infstones.com/), [Moralis](http://moralis.io/)
+| **API/Node Access** | [Nodereal](https://nodereal.io/), [Ankr](https://www.ankr.com/), [Chainstack](https://chainstack.com/build-better-with-binance-smart-chain/), [NowNodes](https://nownodes.io/blog/binance-smart-chain-an-introduction), [Zeeve](https://www.zeeve.io/blockchain-protocols/binance-smart-chain/), [QuickNode](https://www.quicknode.com/), [Covalent](https://www.covalenthq.com/), [Infstones](https://infstones.com/), [Moralis](http://moralis.io/)
 | **NFT APIs** | [Moralis](https://moralis.io/api/nft), [NFTScan](https://bnb.nftscan.com/), [BlockVision](https://blockvision.org/), [Venly](https://www.venly.io/), [Gomu](https://www.gomu.co/), [Bounce Finance](https://bounce.finance/), [NFTrade](https://nftrade.com/)
 | **Archive Node Service** | [Chainstack](https://chainstack.com/build-better-with-binance-smart-chain/), [InfStones](https://infstones.com/), [QuickNode](https://www.quicknode.com/), [Nodereal’s Meganode](https://docs.nodereal.io/nodereal/meganode/archive-node)
 | **Public RPC Endpoints** | [RPC Endpoints](https://docs.bnbchain.org/docs/rpc)| More public nodes are encouraged


### PR DESCRIPTION
Hi,

I came across your BNB Chain Development Tools listing and found that Zeeve is not listed there. I take this opportunity to bring to your attention that Zeeve has been one of the most popular no code web3 platforms for enterprises and has been providing RPC node hosting services. 

Hereby, I request you to please add Zeeve to the BNB Chain Development Tools listing section nodereal, ankr, etc. have also been listed. Zeeve is a cloud-based platform for managing and deploying applications. It provides a comprehensive set of features for developers to quickly and easily deploy their applications to the cloud. Zeeve offers a range of features, including automated deployment of applications to the cloud of your choice, monitoring of applications, automated security and compliance and so on.  

We believe that Zeeve is an excellent addition to the Github directory and would be a great resource for developers looking to quickly and easily deploy their decentralized applications to the cloud. 

If you are interested in discussing this opportunity further or have any questions, please don't hesitate to reach out to me. I would be delighted to provide any additional information.


Thank you for your time and consideration.