### PR TITLE
Updated Steps (and HW specs) for running BSC node with PBSS and additional notes, tips/caution

### DIFF
--- a/docs/validator/fullnode.md
+++ b/docs/validator/fullnode.md
@@ -69,19 +69,6 @@ mv server/data-seed/geth/chaindata node/geth/triecache
 
 :::
 
-:::note
-If you can not download the chaindata snapshot and want to sync from genesis, then you have to generate the genesis block first, which you have already get the genesis.json in Step 2. So just run:
-
-```
-## It will init genesis with Hash-Base Storage Scheme by default.
-geth --datadir <datadir> init ./genesis.json
-
-## It will init genesis with Path-Base Storage Scheme.
-geth --datadir <datadir> --state.scheme path init ./genesis.json
-```
-
-:::
-
 4. Start a full node
 ```
 ./geth --config ./config.toml --datadir ./node  --cache 8000 --rpc.allow-unprotected-txs --txlookuplimit 0
@@ -128,13 +115,19 @@ t=2022-09-08T13:00:33+0000 lvl=info msg="Imported new chain segment"            
 ### Sync From Genesis Block (Not Recommended)
 
 :::note
-To sync from genesis block, you would need a more powerful hardware. Server should at least have 40k IOPS and be at least an i3/i3en series server. 
+To sync from genesis block, you would need a more powerful hardware. Server should at least have 40k IOPS and be at least an i3/i3en series server.  
+
+If you can not download the chaindata snapshot and want to sync from genesis, then you have to generate the genesis block first, for which you have already downloaded the genesis.json in the Step - 2 above where you have downloaded config files.
 :::
 
 1. Write genesis state locally
 
-```bash
-./geth --datadir node init genesis.json
+```
+## It will init genesis with Hash-Base Storage Scheme by default.
+./geth --datadir ./node init ./genesis.json
+
+## It will init genesis with Path-Base Storage Scheme.
+./geth --datadir ./node --state.scheme path init ./genesis.json
 ```
 
 You could see the following output:

--- a/docs/validator/fullnode.md
+++ b/docs/validator/fullnode.md
@@ -45,8 +45,13 @@ chmod -v u+x geth
 Download **genesis.json** and **config.toml** by:
 
 ```bash
+# mainnet
 wget   $(curl -s https://api.github.com/repos/bnb-chain/bsc/releases/latest |grep browser_ |grep mainnet |cut -d\" -f4)
 unzip mainnet.zip
+
+# testnet
+wget   $(curl -s https://api.github.com/repos/bnb-chain/bsc/releases/latest |grep browser_ |grep testnet |cut -d\" -f4)
+unzip testnet.zip
 ```
 
 3. Download snapshot
@@ -55,11 +60,24 @@ Download latest chaindata snapshot from [here](https://github.com/bnb-chain/bsc-
 
 :::note
 Your --datadir flag should point to the folder where the extracted snapshot data is. 
-In our case, we created a new folder named node, and we moved the extracted snapshot data to this folder.
+In our case, we created a new folder named `node`, and we moved the extracted snapshot data to this folder.
 
 ```
 mv server/data-seed/geth/chaindata node/geth/chaindata
 mv server/data-seed/geth/chaindata node/geth/triecache
+```
+
+:::
+
+:::note
+If you can not download the chaindata snapshot and want to sync from genesis, then you have to generate the genesis block first, which you have already get the genesis.json in Step 2. So just run:
+
+```
+## It will init genesis with Hash-Base Storage Scheme by default.
+geth --datadir <datadir> init ./genesis.json
+
+## It will init genesis with Path-Base Storage Scheme.
+geth --datadir <datadir> --state.scheme path init ./genesis.json
 ```
 
 :::
@@ -73,11 +91,26 @@ mv server/data-seed/geth/chaindata node/geth/triecache
 Make sure you use the version of geth you downloaded with wget above, and not your local installation of geth, which might be the wrong version.
 :::
 
+:::caution
+1. Since `v1.3.1`, the flags `--txlookuplimit` has been replaced by `--history.transactions`. Make sure you no longer use `--txlookuplimit`, otherwise, node may not start.
+2. For all geth nodes, DO NOT use `-pipecommit` flag
+
+Note: Please refer this docs: https://www.bnbchain.org/en/blog/hotfix-hardfork-for-bsc-testnet-and-mainnet for more details.
+:::
+
 :::tip
 It is recommended to run a fast node, which is a full node with the flag `--tries-verify-mode none` set if you want high performance and care little about state consistency.
-Check [here](BSC-fast-node.md) for full details on running a fast node.
+Check [here](BSC-fast-node.md) for full details on running a fast node.  
+  
+It will run with Hash-Base Storage Scheme by default
 ```
 ./geth --config ./config.toml --datadir ./node  --cache 8000 --rpc.allow-unprotected-txs --txlookuplimit 0 --tries-verify-mode none
+```
+
+It will run with Path-Base Storage Scheme.  
+It will enable inline state prune, keeping the latest 90000 blocks' history state by default.
+```
+./geth --config ./config.toml --datadir ./node  --cache 8000 --rpc.allow-unprotected-txs --txlookuplimit 0 --tries-verify-mode none --state.scheme path
 ```
 :::
 

--- a/docs/validator/fullnode.md
+++ b/docs/validator/fullnode.md
@@ -16,11 +16,20 @@ sidebar_position: 2
 We support running a full node on **Mac OS X**, **Linux**, and **Windows**.
 
 ## Suggested Requirements
+
+The hardware must meet certain requirements to run a full node on **_mainnet_**:  
+
 - VPS running recent versions of Mac OS X, Linux, or Windows.
 - **IMPORTANT** 3 TB of free disk space, solid-state drive(SSD), gp3, 8k IOPS, 250 MB/S throughput, read latency <1ms. (if node is started with snap sync, it will need NVMe SSD)
 - 16 cores of CPU and 64 GB of memory (RAM)
-- Suggest m5zn.3xlarge instance type on AWS, c2-standard-16 on Google cloud.
+- Suggest m5zn.3xlarge or r7iz.4xlarge instance type on AWS, c2-standard-16 on Google cloud.
 - A broadband Internet connection with upload/download speeds of 5 MB/S
+
+The requirement for **_testnet_**:  
+
+- VPS running recent versions of Mac OS X, Linux, or Windows.
+- 500G of storage for testnet.
+- 4 cores of CPU and 16 gigabytes of memory (RAM).
 
 ## Steps to Run a Fullnode
 

--- a/docs/validator/fullnode.md
+++ b/docs/validator/fullnode.md
@@ -123,6 +123,10 @@ t=2022-09-08T13:00:33+0000 lvl=info msg="Imported new chain segment"            
 
 ### Sync From Genesis Block (Not Recommended)
 
+:::caution
+It is recommended to use HBSS with level DB for archive node, PBSS for archive node is not supported yet.
+:::
+
 :::note
 To sync from genesis block, you would need a more powerful hardware. Server should at least have 40k IOPS and be at least an i3/i3en series server.  
 
@@ -134,9 +138,6 @@ If you can not download the chaindata snapshot and want to sync from genesis, th
 ```
 ## It will init genesis with Hash-Base Storage Scheme by default.
 ./geth --datadir ./node init ./genesis.json
-
-## It will init genesis with Path-Base Storage Scheme.
-./geth --datadir ./node --state.scheme path init ./genesis.json
 ```
 
 You could see the following output:


### PR DESCRIPTION
- Updated and added `--state.scheme path` for PBSS in steps
- Added more notes, tips and caution as per new changes w.r.t. v1.2.15 and v1.3.4 versions
- References:
    -  https://github.com/bnb-chain/bsc/blob/63824a835d0a774732705dec7d6e4f5b4dc58f73/README.md#3-download-snapshot
    - https://www.bnbchain.org/en/blog/hotfix-hardfork-for-bsc-testnet-and-mainnet

- Updated hardware requirements for running bsc mainnet full node.
- Added hardware requirements for running bsc testnet full node.