### PR TITLE
Updated BSC testnet faucet URL

### DIFF
--- a/docs/BSCtestnet.md
+++ b/docs/BSCtestnet.md
@@ -19,7 +19,7 @@ The validators on the testnet are mainly from the development team.
 
 ## How to get Testnet Fund?
 
-The testnet faucet for BNB Chain can be accessed [here](https://testnet.bnbchain.org/faucet-smart).
+The testnet faucet for BNB Chain can be accessed [here](https://www.bnbchain.org/en/testnet-faucet).
 
 ## Explorers for Testnet
 

--- a/docs/ERC721.md
+++ b/docs/ERC721.md
@@ -74,7 +74,7 @@ module.exports = function(deployer) {
 
 We will use [`truffle develop`](https://www.trufflesuite.com/docs/truffle/reference/truffle-commands#develop) to open a Truffle console with a development blockchain
 
-- Head over to [Faucet](https://testnet.bnbchain.org/faucet-smart) and request test BNB
+- Head over to [Faucet](https://www.bnbchain.org/en/testnet-faucet) and request test BNB
 
 
 ```

--- a/docs/beaconchain/develop/testnetandexplorer.md
+++ b/docs/beaconchain/develop/testnetandexplorer.md
@@ -18,13 +18,13 @@ You can connect a node to the testnet by downloading the node binary and testnet
 
 ### How to get Testnet Fund?
 
-> Note: The previous BNB Chain Testnet [Faucet](https://www.binance.com/en/dex/testnet/address) is retired at 2020/08/11 at 1:00 PM (UTC). The testnet faucet has migrated to this page: <https://testnet.bnbchain.org/faucet-smart>
+> Note: The previous BNB Chain Testnet [Faucet](https://www.binance.com/en/dex/testnet/address) is retired at 2020/08/11 at 1:00 PM (UTC). The testnet faucet has migrated to this page: <https://www.bnbchain.org/en/testnet-faucet>
 
 **Steps to claim testnet BNB:**
 
 1. Create a new Wallet of BNB Smart Chain testnet with [Trust Wallet or Binance Extension Wallet](https://docs.bnbchain.org/docs/Wallet#supported-wallets)
 
-2. Get Testnet Fund: https://testnet.bnbchain.org/faucet-smart
+2. Get Testnet Fund: https://www.bnbchain.org/en/testnet-faucet
 
 3. Transfer From BNB Smart Chain to BNB Beacon Chain
 

--- a/docs/bnb-chain-wallet.md
+++ b/docs/bnb-chain-wallet.md
@@ -84,7 +84,7 @@ Now you are all set!
 
 ## Get Testnet BNB from Faucet
 
-* Go to <https://testnet.bnbchain.org/faucet-smart/>
+* Go to <https://www.bnbchain.org/en/testnet-faucet/>
 
 ![img](https://lh6.googleusercontent.com/Q1uDI7LH2lZXvew9selrT5NzL7wKKPtvEnQlPB4mEZW46xb-fphq_Azi9EouvzYKx3IudqwppX6Pai2oFzGlyuJrOvLYlPnZySl2AmHPhpBMeIgEag4sdK_QkycMB826O95tqNQv)
 

--- a/docs/bsc-faucet.md
+++ b/docs/bsc-faucet.md
@@ -9,7 +9,7 @@ dir:
 
 ## Claim tBNB from Online Faucet
 
-To get some tBNB of BSC testnet for testing purposes, you can use the [online faucet](https://testnet.bnbchain.org/faucet-smart) to claim your tokens.
+To get some tBNB of BSC testnet for testing purposes, you can use the [online faucet](https://www.bnbchain.org/en/testnet-faucet) to claim your tokens.
 
 1. Copy your wallet address and paste the address into the textbox
 

--- a/docs/chainide.md
+++ b/docs/chainide.md
@@ -47,7 +47,7 @@ If you want to continue with Binance Wallet, install Binance Wallet, and After i
 
 ### Obtaining Test BNB tokens
 
-Once BNB Smart Chain Test Network has been added to MetaMask, navigate to the [BNB Smart Chain Faucet](https://testnet.bnbchain.org/faucet-smart) to receive test tokens. Tokens are needed to pay for gas fees to deploy and interact with the smart contract. On the faucet page, paste your MetaMask wallet address. Then, click submit and the faucet will send you some test BNBs.
+Once BNB Smart Chain Test Network has been added to MetaMask, navigate to the [BNB Smart Chain Faucet](https://www.bnbchain.org/en/testnet-faucet) to receive test tokens. Tokens are needed to pay for gas fees to deploy and interact with the smart contract. On the faucet page, paste your MetaMask wallet address. Then, click submit and the faucet will send you some test BNBs.
 
 ![img](https://d3gvnlbntpm4ho.cloudfront.net/Using+ChainIDE+BNB+Smart+Chain/BNB_Smart_Chain_Faucet.png)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,7 +28,7 @@ In 2020, the BNB Smart Chain (BSC) was launched. BSC is a blockchain network tha
 
 ### How to Buy BNB Tokens
 As all fees on BNB Chain are paid in BNB, therefore, in order to interact with the BNB Smart Chain network you will need to have some BNB tokens. 
-- BNB tokens can also be received for usage on testnet through the **[Testnet Faucet](https://testnet.bnbchain.org/faucet-smart)**.
+- BNB tokens can also be received for usage on testnet through the **[Testnet Faucet](https://www.bnbchain.org/en/testnet-faucet)**.
 - Refer [here](wallets/wallet-tutorial-overview) for tutorials on different wallets for use with BNB Chain to send/receive/purchase BNB Tokens.
 
 ### Extensive Support of Wallets

--- a/docs/learn/ecosystem.md
+++ b/docs/learn/ecosystem.md
@@ -47,7 +47,7 @@ In the below sections you can find a list of different layers of the BSC Stack.
 | **Public RPC Endpoints** | [RPC Endpoints](https://docs.bnbchain.org/docs/rpc)| More public nodes are encouraged
 | **Community Polling Dashboard** | |
 | **Gas Station Network** | [opengsn](https://opengsn.org/)
-| **Faucet** | [BSC Test Faucet](https://testnet.bnbchain.org/faucet-smart)
+| **Faucet** | [BSC Test Faucet](https://www.bnbchain.org/en/testnet-faucet)
 | **Browser** | [Opera](https://www.opera.com/crypto/)
 | **Dapp Store** | [Dapp Bay](https://dappbay.bnbchain.org/), [Magic Square](https://magicsquare.io/)
 

--- a/docs/migration/evm-chains/token-migration.md
+++ b/docs/migration/evm-chains/token-migration.md
@@ -20,7 +20,7 @@ All you require is a browser-based Web3 wallet (e.g. MetaMask) to interact with 
 You must set up all of the following prerequisites to be able to deploy your Solidity smart contract on BSC:
 * [Download Metamask wallet](https://metamask.io/)
 * [Configure BNB Smart Chain Testnet on Metamask](https://academy.binance.com/en/articles/connecting-metamask-to-binance-smart-chain)
-* [Get BNB Testnet tokens](https://testnet.bnbchain.org/faucet-smart)
+* [Get BNB Testnet tokens](https://www.bnbchain.org/en/testnet-faucet)
 
 ### Setting Up Remix IDE
 * Remix is an online IDE to develop smart contracts.

--- a/docs/migration/non-evm-chains/solana/token-migration.md
+++ b/docs/migration/non-evm-chains/solana/token-migration.md
@@ -82,7 +82,7 @@ You must set up all of the following prerequisites to be able to deploy your sol
 
 - [Download Metamask wallet](https://metamask.io/)
 - [Configure BNB Smart Chain Testnet on Metamask](https://academy.binance.com/en/articles/connecting-metamask-to-binance-smart-chain)
-- [Get BNB testnet tokens](https://testnet.bnbchain.org/faucet-smart)
+- [Get BNB testnet tokens](https://www.bnbchain.org/en/testnet-faucet)
 
 #### Setting Up Remix IDE
 [_For details, refer here_](https://docs.bnbchain.org/docs/remix-new#setting-up-remix-ide)

--- a/docs/nft_blackide.md
+++ b/docs/nft_blackide.md
@@ -124,7 +124,7 @@ We aim to keep this tutorial as simple as possible and hence tend to use as mini
 
 ## Acquire BNB Test Tokens
 
-* Initially, the balance of a newly created key pair is 0.0 ETH. To get BNB test tokens, you can use the [BSC Testnet Faucet](https://testnet.bnbchain.org/faucet-smart/).
+* Initially, the balance of a newly created key pair is 0.0 ETH. To get BNB test tokens, you can use the [BSC Testnet Faucet](https://www.bnbchain.org/en/testnet-faucet/).
 
 * Copy your public address from the keypair manager
 

--- a/docs/remix-new.md
+++ b/docs/remix-new.md
@@ -17,7 +17,7 @@ You must set up all of the following Pre-requisites to be able to deploy your so
 
 * [Download Metamask wallet](https://metamask.io/)
 * [Configure BNB Smart Chain Testnet on Metamask](https://academy.binance.com/en/articles/connecting-metamask-to-binance-smart-chain)
-* [Get BNB testnet tokens](https://testnet.bnbchain.org/faucet-smart)
+* [Get BNB testnet tokens](https://www.bnbchain.org/en/testnet-faucet)
  
 ### Setting Up Remix IDE
 
@@ -88,7 +88,7 @@ Now, We have to deploy our smart contract on BNB Smart Chain Network. For that, 
 - Go ahead and click save
 - Copy your address from Metamask
 
-- Head over to [Faucet](https://testnet.bnbchain.org/faucet-smart) and request test BNB
+- Head over to [Faucet](https://www.bnbchain.org/en/testnet-faucet) and request test BNB
 
 ## Deploy Smart Contract 
 

--- a/docs/replit.md
+++ b/docs/replit.md
@@ -25,7 +25,7 @@ You must set up all of the following Pre-requisites to be able to deploy your so
 1. [Create a Replit account](https://replit.com/signup)
 2. [Download Metamask wallet](https://metamask.io/)
 3. [Configure BNB Smart Chain Testnet on Metamask](https://academy.binance.com/en/articles/connecting-metamask-to-binance-smart-chain)
-4. [Get BNB testnet tokens](https://testnet.bnbchain.org/faucet-smart)
+4. [Get BNB testnet tokens](https://www.bnbchain.org/en/testnet-faucet)
  
 ## Working with a Repl
  

--- a/docs/wallet/AlphaWallet.md
+++ b/docs/wallet/AlphaWallet.md
@@ -27,4 +27,4 @@ It’s ready, and now you can get some testnet BNB from the faucet.
 ## Get Testnet Fund
 1. Copy your address.
 
-2. Go to <https://testnet.bnbchain.org/faucet-smart/>
+2. Go to <https://www.bnbchain.org/en/testnet-faucet/>

--- a/docs/wallet/binance-cn.md
+++ b/docs/wallet/binance-cn.md
@@ -69,7 +69,7 @@
 
 ## 获得测试网BNB
 
-* 打开以下页面 <https://testnet.bnbchain.org/faucet-smart/>
+* 打开以下页面 <https://www.bnbchain.org/en/testnet-faucet/>
 
 ![img](https://lh6.googleusercontent.com/Q1uDI7LH2lZXvew9selrT5NzL7wKKPtvEnQlPB4mEZW46xb-fphq_Azi9EouvzYKx3IudqwppX6Pai2oFzGlyuJrOvLYlPnZySl2AmHPhpBMeIgEag4sdK_QkycMB826O95tqNQv)
 

--- a/docs/wallet/bnb-chain-wallet.md
+++ b/docs/wallet/bnb-chain-wallet.md
@@ -80,7 +80,7 @@ Now you are all set!
 
 ## Get Testnet BNB from Faucet
 
-* Go to <https://testnet.bnbchain.org/faucet-smart/>
+* Go to <https://www.bnbchain.org/en/testnet-faucet/>
 
 ![img](https://lh6.googleusercontent.com/Q1uDI7LH2lZXvew9selrT5NzL7wKKPtvEnQlPB4mEZW46xb-fphq_Azi9EouvzYKx3IudqwppX6Pai2oFzGlyuJrOvLYlPnZySl2AmHPhpBMeIgEag4sdK_QkycMB826O95tqNQv)
 

--- a/docs/wallet/math.md
+++ b/docs/wallet/math.md
@@ -43,7 +43,7 @@ It’s ready, and now you can get some testnet BNB from the faucet.
 
 <img src="https://lh3.googleusercontent.com/1WquPDgLagkXcni9u9yPXzgaagCRd0nzm49cZ516XZSRB_rlOuybVG48C4R2ozhiSlIizxEMI_J7GexZz64E4vUpH362rrAn74GP1ALLOFOZusF8qjM1Xk71cTo5-EWcFvvqpIRL" alt="img" style={{zoom:"33%"}} />
 
-2. Go to <https://testnet.bnbchain.org/faucet-smart/>
+2. Go to <https://www.bnbchain.org/en/testnet-faucet/>
 
 Go to explorer to verify BNB is sent: <https://testnet.bscscan.com/>
 


### PR DESCRIPTION
- Updated BSC testnet faucet URL to `https://www.bnbchain.org/en/testnet-faucet`
- Faucet link: https://www.bnbchain.org/en/testnet-faucet