### PR TITLE
Merged `Nodes` into `Running BSC Nodes` section and re-labelled fast node sidebar labels.

### DIFF
--- a/docs/BSC-fast-node.md
+++ b/docs/BSC-fast-node.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Fast Node
+sidebar_label: BNB Smart Chain Fast Node
 hide_table_of_contents: false
 sidebar_position: 2
 ---

--- a/docs/BSC-separate-node.md
+++ b/docs/BSC-separate-node.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Separate Node
+sidebar_label: BNB Smart Chain Separate Node
 hide_table_of_contents: false
 sidebar_position: 2
 ---

--- a/docs/BSC-verify-node.md
+++ b/docs/BSC-verify-node.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Verify Node
+sidebar_label: BNB Smart Chain Verify Node
 hide_table_of_contents: false
 sidebar_position: 2
 ---

--- a/docs/boot-nodes.md
+++ b/docs/boot-nodes.md
@@ -1,6 +1,6 @@
 ---
 title: Boot Nodes
-sidebar_label: Boot Nodes
+sidebar_label: BNB Smart Chain Boot Nodes
 sidebar_position: 2
 hide_table_of_contents: false
 ---

--- a/sidebars.js
+++ b/sidebars.js
@@ -65,13 +65,7 @@ const sidebars = {
                         type: 'category',
                         collapsed: true,
                         label: 'Running BSC Nodes',
-                        items: ['validator/best-practice','validator/fullnode', 'archivenode', 'validator/node-maintenance', 'validator/upgrade-fullnode', 'validator/docker']
-                      },
-                      {
-                        type: 'category',
-                        collapsed: true,
-                        label: 'Nodes',
-                        items: ['BSC-separate-node','BSC-verify-node', 'BSC-fast-node', 'boot-nodes']
+                        items: ['validator/best-practice','validator/fullnode','BSC-fast-node','archivenode','BSC-separate-node','BSC-verify-node', 'boot-nodes', 'validator/node-maintenance', 'validator/upgrade-fullnode', 'validator/docker']
                       },
                       {
                         type: 'category',


### PR DESCRIPTION
- moved files from `Nodes` section to `Running BSC Nodes` section and renamed their sibebar labels
- Renamed Sidelabes as below:
   - Fast Node -> BNB Smart Chain Fast Node
   - Verify Node -> BNB Smart Chain Verify Node
   - Separate Node -> BNB Smart Chain Separate Node
   -  Boot Nodes -> BNB Smart Chain Boot Nodes
- Removed `Nodes` category from sidebar.js and moved its items to `Running BSC Nodes` category.