### PR TITLE
Added back moralis as RPC provider

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -40,7 +40,7 @@ You could find more endpoints from **[here](https://chainlist.org/chain/56)**.
 
 ### Thrid-Party RPC Providers
 
-<!--* [Moralis](https://moralis.io/): <https://moralis.io/speedy-nodes/>-->
+* **Moralis:** <https://moralis.io/nodes/?utm_source=bnb-docs&utm_medium=partner-docs>
 
 * **NodeReal:** <https://docs.nodereal.io/nodereal/meganode/introduction>
 


### PR DESCRIPTION
Moralis has re-launched its node product. So added it back to node provider list.