### PR TITLE
chore: refine docs after bc fusion

### DIFF
--- a/docs/bc-fusion/overview.md
+++ b/docs/bc-fusion/overview.md
@@ -5,6 +5,8 @@ title: Overview - BC Fusion
 
 # Overview
 
+**BNB Beacon Chain has been shut down at block height 385,251,927 since December 3, 2024.**
+
 BNB Beacon Chain is a blockchain developed by the BNB Chain community that implements a vision of a decentralized
 exchange (DEX) for digital assets. Besides this, Beacon Chain and BSC is a dual-chain structure: Beacon Chain helps to
 enhance the security of BSC as a staking and governance layer. With the rise of various other forms of Dex, order-book
@@ -28,8 +30,7 @@ There will be several pahses to retrie Beacon Chain:
 - **Second Sunset Fork** - More Beacon chain transactions will be disabled, for example,MsgSideChainSubmitProposal. All
   TimeLock and AtomicSwap will automatically be refunded to the user's
   wallet. All the BSC delegation will be undelegated automatically.
-- **Final Sunset Fork** - Cross-chain communication between the Beacon Chain and BSC will be completely stopped. (
-  Estimated time on mainnet: 2024 Sep)
+- **Final Sunset Fork** - Cross-chain communication between the Beacon Chain and BSC will be completely stopped.
 - **Post BC Fusion** - Beacon Chain will be dumped and and a merkle tree will be generated for recover the assets, which
   are binded to BSC however not transffered to BSC yet.
 

--- a/docs/bc-fusion/post-fusion/faq.md
+++ b/docs/bc-fusion/post-fusion/faq.md
@@ -44,8 +44,7 @@ are the owner of the assets. Please take care of your key/mnemonic.
     - Mainnet API Endpoint: https://dex.bnbchain.org/api/v1/account/{bnb_address}
 * The snapshot file can be downloaded from Greenfield, R2, and so on. The users can download the snapshot file and set up
   a local BC node for retrieving any data on the blockchain.
-    - Testnet snpashot file: https://github.com/bnb-chain/node-dump/blob/master/Readme.md    
-    - Mainnet snpashot file: To be updated.
+    - Testnet/Mainnet snpashot file: https://github.com/bnb-chain/node-dump/blob/master/Readme.md
 
 ## 4. Can I still acccess the BC releated services or products after the fusion?
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,37 +79,6 @@ nav:
       - Bohr Hardfork(BSC): ./announce/bohr-bsc.md
       - Altai Hardfork(Gnfd): ./announce/altai-gnfd.md
       - Final Sunset of BC (Mainnet): ./announce/final-sunset-bc-mainnet.md
-  - BNB Chain Fusion:
-    - BNB Chain Fusion: ./bc-fusion/index.md
-    - Overview: ./bc-fusion/overview.md
-    - Post Fustion:
-      - Merkle Proof Verification: ./bc-fusion/post-fusion/merkle-tree-verify.md
-      - Token Recovery: ./bc-fusion/post-fusion/token-recovery.md
-      - FAQ: ./bc-fusion/post-fusion/faq.md
-    - For Users:
-      - Manage Your Assets: ./bc-fusion/users/assets.md
-      - Manage Your Atomic Swaps: ./bc-fusion/users/swaps.md
-      - Manage Your TimeLocks: ./bc-fusion/users/timelocks.md
-      - Manage Your Old Delegations: ./bc-fusion/users/stake-migration.md
-      - BEP153 and LSD Stake Migration: ./bc-fusion/users/bep153-stake-migration.md
-      - Manage Your New Delegations: ./bc-fusion/users/new-stake.md
-      - Participate in Governance: ./bc-fusion/users/gov.md
-    - For Token Issuers:
-      - Bind Your Tokens: ./bc-fusion/owners/bind.md
-      - Cross Chain Liquidity Check and Repair: ./bc-fusion/owners/liquidity-check.md
-    - For Validators:
-      - Create New Validators: ./bc-fusion/validators/creation.md
-      - Migrate Your Validators: ./bc-fusion/validators/migrations.md
-      - Key Management: ./bc-fusion/validators/key-management.md
-    - For Developers:
-      - New Staking: ./bc-fusion/developers/staking.md
-      - New Governance: ./bc-fusion/developers/gov.md
-      - Cross Chain Redelegation: ./bc-fusion/developers/crosschain-redelegation.md
-      - Build-in System Contracts: ./bc-fusion/developers/system-contracts.md
-    - Native Staking & Governance:
-      - Staking: ./bc-fusion/validators/staking.md
-      - Slash: ./bc-fusion/validators/slash.md
-      - Governance: ./bc-fusion/validators/gov.md
   - BNB Smart Chain:
     - BNB Smart Chain: ./bnb-smart-chain/index.md
     - Overview: ./bnb-smart-chain/overview.md
@@ -326,7 +295,13 @@ nav:
          - Company Tokenization Tutorial: ./showcase/tokenization/company-tokenization.md
          - RWA Tokenization Tutorial: ./showcase/tokenization/rwa-tokenization.md
          - NFT Loyalty Program Tutorial: ./showcase/tokenization/nft-loyalty-programs.md
-     
+  - BNB Chain Fusion:
+      - BNB Chain Fusion: ./bc-fusion/index.md
+      - Overview: ./bc-fusion/overview.md
+      - Post Fustion:
+          - Merkle Proof Verification: ./bc-fusion/post-fusion/merkle-tree-verify.md
+          - Token Recovery: ./bc-fusion/post-fusion/token-recovery.md
+          - FAQ: ./bc-fusion/post-fusion/faq.md
 
 markdown_extensions:
   - toc:

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,10 +1,12 @@
 {% extends "base.html" %}
 
+{#
 {% block announce %}
 <div>
-    BNB Beacon Chain has been shut down at block height 385,251,927 since December 3, 2024. <a href="https://www.bnbchain.org/en/bnb-chain-fusion" target="_blank">Learn More</a>
+    announcement goes here
 </div>
 {% endblock %}
+#}
 
 {% block htmltitle %}
     {% if page.meta and page.meta.title %}


### PR DESCRIPTION
the docs are not deleted yet, for there are links to them. just do not show them in the nav.