### PR TITLE
Add ethfaucet.com faucet

### DIFF
--- a/docs/bnb-smart-chain/developers/faucet.md
+++ b/docs/bnb-smart-chain/developers/faucet.md
@@ -28,3 +28,5 @@ You can also claim tBNB from the following third-party faucets
 2. https://faucet.chainstack.com/bnb-testnet-faucet
 
 3. https://thirdweb.com/opbnb-testnet
+
+4. [ethfaucet.com](https://ethfaucet.com?utm_source=bnb_docs&utm_medium=docs)


### PR DESCRIPTION
Description
Adding a new faucet (ethfaucet.com) to the docs.
ethfaucet.com provides developers with gas on BNB network for free, claimable once every 24 hours.

Additional context
ethfaucet.com is maintained and powered by BringID. BringID is a proof-of-humanity solution from web accounts helping crypto apps to resist sybil attacks and bot abuse.