### PR TITLE
Replace OpenClaw Skills with BNB Chain Skills

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -914,3 +914,103 @@ For **parameter names, examples, and detailed usage**, see the [bnbchain-skills]
 - **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
 - **npm:** `npx @bnb-chain/mcp@latest`
 - **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -814,3 +814,103 @@ For **parameter names, examples, and detailed usage**, see the [bnbchain-skills]
 - **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
 - **npm:** `npx @bnb-chain/mcp@latest`
 - **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -614,3 +614,103 @@ For **parameter names, examples, and detailed usage**, see the [bnbchain-skills]
 - **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
 - **npm:** `npx @bnb-chain/mcp@latest`
 - **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -110,3 +110,103 @@ For **parameter names, examples, and detailed usage**, see the [bnbchain-skills]
 - **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
 - **npm:** `npx @bnb-chain/mcp@latest`
 - **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -414,3 +414,103 @@ For **parameter names, examples, and detailed usage**, see the [bnbchain-skills]
 - **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
 - **npm:** `npx @bnb-chain/mcp@latest`
 - **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2,6 +2,10 @@
 ## BNB Chain Skills
 > Source: https://docs.bnbchain.org/showcase/mcp/SKILLS/
 
+---
+title: BNB Chain Skills
+---
+
 # BNB Chain Skills
 
 This page is for **AI agents** that integrate with BNB Chain. It summarizes the BNB Chain MCP skill: how to connect, configure credentials, use tools, and where to check agent registration.
@@ -10,6 +14,106 @@ This page is for **AI agents** that integrate with BNB Chain. It summarizes the 
 
 ---
 
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
 ## 1. Connection and credentials
 
 - **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -714,3 +714,103 @@ For **parameter names, examples, and detailed usage**, see the [bnbchain-skills]
 - **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
 - **npm:** `npx @bnb-chain/mcp@latest`
 - **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -514,3 +514,103 @@ For **parameter names, examples, and detailed usage**, see the [bnbchain-skills]
 - **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
 - **npm:** `npx @bnb-chain/mcp@latest`
 - **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -314,3 +314,103 @@ For **parameter names, examples, and detailed usage**, see the [bnbchain-skills]
 - **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
 - **npm:** `npx @bnb-chain/mcp@latest`
 - **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1,0 +1,112 @@
+
+## BNB Chain Skills
+> Source: https://docs.bnbchain.org/showcase/mcp/SKILLS/
+
+# BNB Chain Skills
+
+This page is for **AI agents** that integrate with BNB Chain. It summarizes the BNB Chain MCP skill: how to connect, configure credentials, use tools, and where to check agent registration.
+
+**Skill repository:** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) — installable skills and reference docs for BNB Chain MCP.
+
+---
+
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1514,3 +1514,103 @@ For **parameter names, examples, and detailed usage**, see the [bnbchain-skills]
 - **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
 - **npm:** `npx @bnb-chain/mcp@latest`
 - **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1214,3 +1214,103 @@ For **parameter names, examples, and detailed usage**, see the [bnbchain-skills]
 - **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
 - **npm:** `npx @bnb-chain/mcp@latest`
 - **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -8,12 +8,54 @@ title: BNB Chain Skills
 
 # BNB Chain Skills
 
-This page is for **AI agents** that integrate with BNB Chain. It summarizes the BNB Chain MCP skill: how to connect, configure credentials, use tools, and where to check agent registration.
+This page is for **AI agents** that integrate with BNB Chain. It summarizes the BNB Chain MCP skill: how to connect, configure credentials, use tools, and check agent registration.
 
 **Skill repository:** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) — installable skills and reference docs for BNB Chain MCP.
 
----
+## 1. Connection and credentials
 
+- **Run the server:** `npx @bnb-chain/mcp@latest` (source: [bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)).
+- **RPC:** Default chains use built-in RPC; no config needed unless self-hosting or using a custom RPC.
+- **PRIVATE_KEY:** Leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to your MCP client config.
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** Use `--sse` flag. **Local dev server:** `"url": "http://localhost:3001/sse"` with the same `env`.
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with `register_erc8004_agent`.
+2. Check registration: Mainnet [8008scan.io](https://www.8004scan.io/), Testnet [testnet.8004scan.io](https://testnet.8004scan.io/).
+
+## 4. Tools overview
+
+- **Read-only:** blocks, transactions, network info, balances, token/NFT metadata, `read_contract`.
+- **State-changing:** `transfer_*`, `approve_token_spending`, `write_contract`, Greenfield writes — require `PRIVATE_KEY`.
+- **ERC-8004:** `register_erc8004_agent`, `set_agent_uri`, getters.
+- **Prompts:** analyze_block, analyze_transaction, analyze_address, analyze_token, compare_networks, how_to_register_mcp_as_erc8004_agent.
+
+## 5. Reference docs
+
+- [bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
 ## 1. Connection and credentials
 
 - **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1414,3 +1414,103 @@ For **parameter names, examples, and detailed usage**, see the [bnbchain-skills]
 - **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
 - **npm:** `npx @bnb-chain/mcp@latest`
 - **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -116,6 +116,106 @@ For **parameter names, examples, and detailed usage**, see the [bnbchain-skills]
 - **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
 ## 1. Connection and credentials
 
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
+## 1. Connection and credentials
+
 - **Run the server:** `npx @bnb-chain/mcp@latest` (source: [bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)).
 - **RPC:** Default chains use built-in RPC; no config needed unless self-hosting or using a custom RPC.
 - **PRIVATE_KEY:** Leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -27,6 +27,106 @@ Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings
 
 **Default (stdio):**
 
+
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
 ```json
 {
   "mcpServers": {

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1314,3 +1314,103 @@ For **parameter names, examples, and detailed usage**, see the [bnbchain-skills]
 - **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
 - **npm:** `npx @bnb-chain/mcp@latest`
 - **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -8,10 +8,112 @@ title: BNB Chain Skills
 
 # BNB Chain Skills
 
-This page is for **AI agents** that integrate with BNB Chain. It summarizes the BNB Chain MCP skill: how to connect, configure credentials, use tools, and check agent registration.
+This page is for **AI agents** that integrate with BNB Chain. It summarizes the BNB Chain MCP skill: how to connect, configure credentials, use tools, and where to check agent registration.
 
 **Skill repository:** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) — installable skills and reference docs for BNB Chain MCP.
 
+---
+
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
 ## 1. Connection and credentials
 
 - **Run the server:** `npx @bnb-chain/mcp@latest` (source: [bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)).

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2,6 +2,116 @@
 ## BNB Chain Skills
 > Source: https://docs.bnbchain.org/showcase/mcp/SKILLS/
 
+> Source: https://docs.bnbchain.org/showcase/mcp/SKILLS/
+
+# BNB Chain Skills
+
+This page is for **AI agents** that integrate with BNB Chain. It summarizes the BNB Chain MCP skill: how to connect, configure credentials, use tools, and where to check agent registration.
+
+**Skill repository:** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) — installable skills and reference docs for BNB Chain MCP.
+
+---
+
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
 ## BNB Chain Skills
 > Source: https://docs.bnbchain.org/showcase/mcp/SKILLS/
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1114,3 +1114,103 @@ For **parameter names, examples, and detailed usage**, see the [bnbchain-skills]
 - **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
 - **npm:** `npx @bnb-chain/mcp@latest`
 - **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1014,3 +1014,103 @@ For **parameter names, examples, and detailed usage**, see the [bnbchain-skills]
 - **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
 - **npm:** `npx @bnb-chain/mcp@latest`
 - **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2,6 +2,9 @@
 ## BNB Chain Skills
 > Source: https://docs.bnbchain.org/showcase/mcp/SKILLS/
 
+## BNB Chain Skills
+> Source: https://docs.bnbchain.org/showcase/mcp/SKILLS/
+
 ---
 title: BNB Chain Skills
 ---
@@ -14,6 +17,106 @@ This page is for **AI agents** that integrate with BNB Chain. It summarizes the 
 
 ---
 
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
 ## 1. Connection and credentials
 
 - **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -27,6 +27,106 @@ Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings
 
 **Default (stdio):**
 
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
 
 {
   "mcpServers": {

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2,8 +2,6 @@
 ## BNB Chain Skills
 > Source: https://docs.bnbchain.org/showcase/mcp/SKILLS/
 
-> Source: https://docs.bnbchain.org/showcase/mcp/SKILLS/
-
 # BNB Chain Skills
 
 This page is for **AI agents** that integrate with BNB Chain. It summarizes the BNB Chain MCP skill: how to connect, configure credentials, use tools, and where to check agent registration.
@@ -12,6 +10,106 @@ This page is for **AI agents** that integrate with BNB Chain. It summarizes the 
 
 ---
 
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
 ## 1. Connection and credentials
 
 - **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -125,6 +125,106 @@ Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings
 
 **Default (stdio):**
 
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
 
 {
   "mcpServers": {

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1614,3 +1614,103 @@ For **parameter names, examples, and detailed usage**, see the [bnbchain-skills]
 - **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
 - **npm:** `npx @bnb-chain/mcp@latest`
 - **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.
+## 1. Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,1 +1,1 @@
-- [BNB Chain Skills](https://docs.bnbchain.org/showcase/mcp/SKILLS/): BNB Chain MCP skill overview covering connection, credentials, tools, ERC-8004 agent registration, and reference docs.
+- [BNB Chain Skills](https://docs.bnbchain.org/showcase/mcp/SKILLS/): BNB Chain MCP skill overview covering connection, credentials, tool categories, ERC-8004 agent registration, prompts, and reference docs.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,1 @@
+- [BNB Chain Skills](https://docs.bnbchain.org/showcase/mcp/SKILLS/): BNB Chain MCP skill overview covering connection, credentials, tools, ERC-8004 agent registration, and reference docs.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,1 +1,1 @@
-- [BNB Chain Skills](https://docs.bnbchain.org/showcase/mcp/SKILLS/): BNB Chain MCP skill overview for AI agents covering connection, credentials, MCP server config, ERC-8004 agent registration, tool categories, prompts, reference docs, and safety best practices.
+- [BNB Chain Skills](https://docs.bnbchain.org/showcase/mcp/SKILLS/): BNB Chain MCP skill overview for AI agents — connection, credentials, server config, ERC-8004 agent registration, tool categories, reference docs, and safety best practices.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,1 +1,1 @@
-- [BNB Chain Skills](https://docs.bnbchain.org/showcase/mcp/SKILLS/): BNB Chain MCP skill overview covering connection, credentials, tool categories, ERC-8004 agent registration, prompts, and reference docs.
+- [BNB Chain Skills](https://docs.bnbchain.org/showcase/mcp/SKILLS/): BNB Chain MCP skill overview covering connection, credentials, MCP server config, ERC-8004 agent registration, tool categories, prompts, reference docs, and safety best practices.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,1 +1,1 @@
-- [BNB Chain Skills](https://docs.bnbchain.org/showcase/mcp/SKILLS/): BNB Chain MCP skill overview covering connection, credentials, MCP server config, ERC-8004 agent registration, tool categories, prompts, reference docs, and safety best practices.
+- [BNB Chain Skills](https://docs.bnbchain.org/showcase/mcp/SKILLS/): BNB Chain MCP skill overview for AI agents covering connection, credentials, MCP server config, ERC-8004 agent registration, tool categories, prompts, reference docs, and safety best practices.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,1 +1,1 @@
-- [BNB Chain Skills](https://docs.bnbchain.org/showcase/mcp/SKILLS/): BNB Chain MCP skill overview for AI agents — connection, credentials, server config, ERC-8004 agent registration, tool categories, reference docs, and safety best practices.
+- [BNB Chain Skills](https://docs.bnbchain.org/showcase/mcp/SKILLS/): BNB Chain MCP skill overview for AI agents — connection, credentials, server config, ERC-8004 agent registration, tool categories, MCP prompts, reference docs, and safety best practices.

--- a/docs/showcase/mcp/SKILLS.md
+++ b/docs/showcase/mcp/SKILLS.md
@@ -1,28 +1,112 @@
 ---
-title: OpenClaw Skills
+title: BNB Chain Skills
 ---
 
-# OpenClaw Skills
+# BNB Chain Skills
 
-This page is for **AI agents** (e.g. OpenClaw). It contains the agent prompt, available BNB Chain skills, and where to check agent registration.
+This page is for **AI agents** that integrate with BNB Chain. It summarizes the BNB Chain MCP skill: how to connect, configure credentials, use tools, and where to check agent registration.
 
----
-
-## 1. Agent Prompt
-
-**I'm a human**
-
-- **Manual:** Read this skill page and follow the instructions to connect your agent to BNB Chain.
-- **bnbchain:** `npx @bnb-chain/mcp@latest`
-
-**I'm an agent**
-
-- **bnbchain:** `npx @bnb-chain/mcp@latest`
-- **manual:** `curl -s https://raw.githubusercontent.com/bnb-chain/bnb-chain.github.io/main/docs/showcase/mcp/skills.md`
+**Skill repository:** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) — installable skills and reference docs for BNB Chain MCP.
 
 ---
 
-## 2. Agent registration
+## 1. Connection and credentials
 
-- **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
-- **Testnet:** Agents should inform their owners to visit **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)** to see their registration
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 2. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [bnbchain-skills skill references](https://github.com/bnb-chain/bnbchain-skills/tree/main/skills/bnbchain-mcp-skill/references)).
+2. **Mainnet:** Check agent registration and status at **[https://www.8004scan.io/](https://www.8004scan.io/)**
+3. **Testnet:** Check registration at **[https://testnet.8004scan.io/](https://testnet.8004scan.io/)**
+
+---
+
+## 4. Tool categories (quick reference)
+
+Most EVM tools accept **`network`** (optional): chain name or ID, e.g. `bsc`, `opbnb`, `ethereum`, `base`. Default is `bsc`. Use **`get_supported_networks`** to list supported networks.
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### MCP prompts
+
+- **analyze_block** — Analyze a block and its contents  
+- **analyze_transaction** — Analyze a specific transaction  
+- **analyze_address** — Analyze an EVM address  
+- **interact_with_contract** — Guidance on interacting with a smart contract  
+- **explain_evm_concept** — Explain an EVM concept  
+- **compare_networks** — Compare EVM-compatible networks  
+- **analyze_token** — Analyze an ERC20 or NFT token  
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent  
+
+---
+
+## 5. Reference docs (per-tool usage)
+
+For **parameter names, examples, and detailed usage**, see the [bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills) repo:
+
+| Reference | Content |
+|-----------|---------|
+| [evm-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [erc8004-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [greenfield-tools-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [prompts-reference.md](https://github.com/bnb-chain/bnbchain-skills/blob/main/skills/bnbchain-mcp-skill/references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Prefer testnet** when the network is unspecified for writes or agent registration.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp)
+- **BNB Chain skills (installable skill + references):** [github.com/bnb-chain/bnbchain-skills](https://github.com/bnb-chain/bnbchain-skills)
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.


### PR DESCRIPTION
Rewrite and expand the MCP skills doc: retitle from OpenClaw to BNB Chain Skills and replace the short agent prompt with comprehensive integration guidance. Adds connection & credential instructions, MCP server config (stdio and SSE) with example JSON, PRIVATE_KEY usage and read-only vs state-changing guidance, ERC-8004 agent registration steps, a tools/categories quick reference and MCP prompts list, per-tool reference links, safety/best-practices, and documentation links to the bnbchain repos and npm. Removes the old minimal agent prompt content and reorganizes the page for BNB Chain MCP consumers.