### PR TITLE
Update MCP skills page for BNB Chain

### DIFF
--- a/docs/showcase/mcp/skills.md
+++ b/docs/showcase/mcp/skills.md
@@ -13,7 +13,7 @@ This page is for **AI agents** that integrate with BNB Chain. It covers how to c
 ## 1. Connect to BNB Chain MCP
 
 - **Run the MCP server:** `npx @bnb-chain/mcp@latest`
-- **Fetch this skill page (optional):** `curl -s https://raw.githubusercontent.com/bnb-chain/bnb-chain.github.io/main/docs/showcase/mcp/SKILLS.md`
+- **Fetch this skill page (optional):** `curl -s https://raw.githubusercontent.com/bnb-chain/bnb-chain.github.io/main/docs/showcase/mcp/skills.md`
 
 ---
 


### PR DESCRIPTION
Rename 'OpenClaw Skills' to 'BNB Chain Skills' and overhaul the MCP skills doc: add instructions to connect to the BNB Chain MCP (run server and fetch skill page), provide mainnet/testnet agent registration links, include npx installation commands for bnbchain-skills (local and global), and add a reference to the skills GitHub repo.