### PR TITLE
Updated information

### DIFF
--- a/docs/bnb-greenfield/for-developers/tutorials/access-control/cross-chain-access-control-by-sdk.md
+++ b/docs/bnb-greenfield/for-developers/tutorials/access-control/cross-chain-access-control-by-sdk.md
@@ -251,7 +251,7 @@ forge script foundry-scripts/GroupHub.s.sol:GroupHubScript \
 --private-key ${your private key} \
 --sig "addMember(address operator, uint256 groupId, address member)" \
 ${the owner of the group} ${your group id} ${the member address to add} \
--f https://data-seed-prebsc-1-s1.binance.org:8545/ \
+-f https://bsc-testnet-dataseed.bnbchain.org \
 --legacy --ffi --broadcast
 ```
 

--- a/docs/bnb-opbnb/core-concepts/gas-and-fees.md
+++ b/docs/bnb-opbnb/core-concepts/gas-and-fees.md
@@ -16,7 +16,7 @@ OpBNB is a Layer 2 scaling solution that aims to achieve higher throughput and l
 | ------------- | ---------------- | ---------------------------- |
 | opBNB Testnet | 8 wei (dynamic)  | 1001 wei                         |
 | opBNB Mainnet | 8 wei (dynamic)  | 1001 wei                         |
-| BSC Testnet   | 0                | 0.05 Gwei (standard)         |
+| BSC Testnet   | 0                | 0.1 Gwei (standard)         |
 | BSC Mainnet   | 0                | 0.05 Gwei (standard)         |
 
 ## What does this means

--- a/docs/bnb-opbnb/core-concepts/gas-and-fees.md
+++ b/docs/bnb-opbnb/core-concepts/gas-and-fees.md
@@ -16,8 +16,8 @@ OpBNB is a Layer 2 scaling solution that aims to achieve higher throughput and l
 | ------------- | ---------------- | ---------------------------- |
 | opBNB Testnet | 8 wei (dynamic)  | 1001 wei                         |
 | opBNB Mainnet | 8 wei (dynamic)  | 1001 wei                         |
-| BSC Testnet   | 0                | 3                            |
-| BSC Mainnet   | 0                | 3                            |
+| BSC Testnet   | 0                | 0.05 Gwei (standard)         |
+| BSC Mainnet   | 0                | 0.05 Gwei (standard)         |
 
 ## What does this means
 

--- a/docs/bnb-opbnb/core-concepts/opbnb-metrics.md
+++ b/docs/bnb-opbnb/core-concepts/opbnb-metrics.md
@@ -40,7 +40,7 @@ Our goal is to provide a scaling solution for network congestion problems for hi
 | **Gas Price Model**  | EIP-1559   | [Gas Price Auction](https://bscscan.com/gastracker) | EIP-1559     |
 | **Block Gas Limit**  | **50M**   | [55M](https://www.bscscan.com/chart/gaslimit)      | 30M          |
 | **Block time**       | **0.25s**     | 0.45s                                                  | 12s          |
-| **Transaction Cost** | **$0.001** | $0.03                                               | $1           |
+| **Transaction Cost** | **$0.001** | ~$0.005                                             | $1           |
 
 
 

--- a/docs/bnb-opbnb/core-concepts/opbnb-metrics.md
+++ b/docs/bnb-opbnb/core-concepts/opbnb-metrics.md
@@ -25,7 +25,7 @@ Compared with other L2 solutions on the Ethereum, like **OP Mainnet** and **Arbi
 | **VM**                 | EVM                   | EVM          | EVM          |
 | **Gas Fee**            | **$0.001**            | $0.05        | $0.1         |
 | **Block Gas Limit**    | **100M(150M 2024Q1)** | 30M          | 32M          |
-| **Block time**         | **1s**                | 2s           | 0.25s(Min)   |
+| **Block time**         | **0.25s**                | 2s           | 0.25s(Min)   |
 | **Withdraw/ Finality** | 7 days                | 7 days       | 7 days       |
 | **TPS (Transfer)**     | **4500+**             | 700+         | 4000+        |
 

--- a/docs/bnb-opbnb/core-concepts/opbnb-metrics.md
+++ b/docs/bnb-opbnb/core-concepts/opbnb-metrics.md
@@ -39,7 +39,7 @@ Our goal is to provide a scaling solution for network congestion problems for hi
 | **VM**               | EVM        | EVM                                                 | EVM          |
 | **Gas Price Model**  | EIP-1559   | [Gas Price Auction](https://bscscan.com/gastracker) | EIP-1559     |
 | **Block Gas Limit**  | **100M**   | [140M](https://www.bscscan.com/chart/gaslimit)      | 30M          |
-| **Block time**       | **0.25s**     | 0.75s                                                  | 12s          |
+| **Block time**       | **0.25s**     | 0.45s                                                  | 12s          |
 | **Transaction Cost** | **$0.001** | $0.03                                               | $1           |
 
 

--- a/docs/bnb-opbnb/core-concepts/opbnb-metrics.md
+++ b/docs/bnb-opbnb/core-concepts/opbnb-metrics.md
@@ -38,7 +38,7 @@ Our goal is to provide a scaling solution for network congestion problems for hi
 | **Gas Token**        | BNB        | BNB                                                 | ETH          |
 | **VM**               | EVM        | EVM                                                 | EVM          |
 | **Gas Price Model**  | EIP-1559   | [Gas Price Auction](https://bscscan.com/gastracker) | EIP-1559     |
-| **Block Gas Limit**  | **100M**   | [140M](https://www.bscscan.com/chart/gaslimit)      | 30M          |
+| **Block Gas Limit**  | **50M**   | [55M](https://www.bscscan.com/chart/gaslimit)      | 30M          |
 | **Block time**       | **0.25s**     | 0.45s                                                  | 12s          |
 | **Transaction Cost** | **$0.001** | $0.03                                               | $1           |
 

--- a/docs/bnb-opbnb/core-concepts/opbnb-metrics.md
+++ b/docs/bnb-opbnb/core-concepts/opbnb-metrics.md
@@ -39,7 +39,7 @@ Our goal is to provide a scaling solution for network congestion problems for hi
 | **VM**               | EVM        | EVM                                                 | EVM          |
 | **Gas Price Model**  | EIP-1559   | [Gas Price Auction](https://bscscan.com/gastracker) | EIP-1559     |
 | **Block Gas Limit**  | **100M**   | [140M](https://www.bscscan.com/chart/gaslimit)      | 30M          |
-| **Block time**       | **1s**     | 3s                                                  | 12s          |
+| **Block time**       | **0.25s**     | 0.75s                                                  | 12s          |
 | **Transaction Cost** | **$0.001** | $0.03                                               | $1           |
 
 

--- a/docs/bnb-smart-chain/developers/faucet.md
+++ b/docs/bnb-smart-chain/developers/faucet.md
@@ -12,9 +12,6 @@ To get some tBNB of BSC testnet for testing purposes, you can use the [online fa
 2. Select the tokens you need to claim. Major pegged tokens like BUSD, USDT, and others are supported. 
 
 
-* Please note if your wallet balance is larger than **1 tBNB**, you can not get new tBNB from the Discord bot faucet.*
-
-
 ## Discord Faucet is no longer available
 
 Discord Faucet is no longer available as of September 2025.

--- a/docs/bnb-smart-chain/faq/tokens-not-showing-in-wallet.md
+++ b/docs/bnb-smart-chain/faq/tokens-not-showing-in-wallet.md
@@ -35,7 +35,7 @@ In your wallet (MetaMask, Trust Wallet, etc.):
 
 If needed, add the network manually:
 - For BSC:  
-  RPC URL: `https://bsc-dataseed.binance.org/`  
+  RPC URL: `https://bsc-dataseed.bnbchain.org`  
   Chain ID: `56`  
 - For opBNB:  
   RPC URL: `https://opbnb-mainnet-rpc.bnbchain.org/`  

--- a/docs/bnb-smart-chain/introduction.md
+++ b/docs/bnb-smart-chain/introduction.md
@@ -4,12 +4,12 @@ title: Introduction - BSC Develop
 
 # Introduction
 
-BNB Smart Chain is an innovative solution to bring programmability and interoperability to BNB Beacon Chain. BNB Smart Chain relies on a system of 55 validators with Proof of Staked Authority (PoSA) consensus that can support short block time and lower fees. The most bonded validator candidates of staking will become validators and produce blocks. The double-sign detection, malicious vote detection and other slashing logic guarantee security, stability, and chain finality. 
-Other than the 32 active validators, BSC will introduce more validators, e.g. another 23 inactive validators, into the validator set as backups, which will be called "Candidates".
+BNB Smart Chain is an innovative solution to bring programmability and interoperability to BNB Beacon Chain. BNB Smart Chain relies on a system of 45 validators with Proof of Staked Authority (PoSA) consensus that can support short block time and lower fees. The most bonded validator candidates of staking will become validators and produce blocks. The double-sign detection, malicious vote detection and other slashing logic guarantee security, stability, and chain finality. 
+The active validator set consists of 45 validators: 21 Cabinet and 24 Candidates. BSC may also introduce additional validators into the validator set as backups.
 
-Candidates will produce blocks and charge gas fees in BSC mainnet, but in a much less chance than the official validator set of 32 elected. The unavailable candidates will be slashed as well though in a smaller size. A decent motivation is expected to be maintained so that the candidate validators are willing to ensure the quality and help secure BSC.
+Candidates will produce blocks and charge gas fees in BSC mainnet, but in a much less chance than the official validator set of 45 (21 Cabinet + 24 Candidates). The unavailable candidates will be slashed as well though in a smaller size. A decent motivation is expected to be maintained so that the candidate validators are willing to ensure the quality and help secure BSC.
 
-In an extreme case, if a majority of the active 32 validators get attacked and offline, Candidate Validators can report to BNB Beacon Chain about the stale blocking, resume it and eventually propose a re-election of the active validator set.
+In an extreme case, if a majority of the active 45 validators get attacked and offline, Candidate Validators can report to BNB Beacon Chain about the stale blocking, resume it and eventually propose a re-election of the active validator set.
 
 The BNB Smart Chain also supports EVM-compatible smart contracts and protocols. Cross-chain transfer and other communication are possible due to native support of interoperability. The BNB Smart Chain will be:
 

--- a/docs/bnb-smart-chain/introduction.md
+++ b/docs/bnb-smart-chain/introduction.md
@@ -36,8 +36,8 @@ Fast finalization can greatly improve user experience. The `Fast Finality` featu
 
 The consensus protocol of BSC fulfills the following goals:
 
-1. Short Blocking time, 3 seconds on mainnet.
-2. It requires quite short time to confirm the finality of transactions, around 6s for mainnet after the coming Plato upgrade.
+1. Short block time, **0.45 seconds** on mainnet (reduced from 3s through the Lorentz, Maxwell, and Fermi hardforks).
+2. It requires very short time to confirm the finality of transactions, approximately **1 second** on mainnet with Fast Finality enabled.
 3. There is no inflation of native token: BNB, the block reward is collected from transaction fees, and it will be paid in BNB.
 4. It is 100% compatible with Ethereum system.
 5. It allows modern proof-of-stake blockchain network governance.
@@ -46,14 +46,14 @@ The consensus protocol of BSC fulfills the following goals:
 Given there are more than ½\*N+1 validators are honest, PoA based networks usually work securely and properly. However, there are still cases where certain amount Byzantine validators may still manage to attack the network, e.g. through the [Clone Attack](https://arxiv.org/pdf/1902.10244.pdf). BSC does introduce Slashing logic to penalize Byzantine validators for double signing or inavailability. This Slashing logic will expose the malicious validators in a very short time and make the "Clone Attack" very hard or extremely non-beneficial to execute.
 
 ## Fast Finality
-Finality is critical for blockchain security, once the block is finalized, it wouldn’t be reverted anymore. The fast finality feature is very useful, the users can make sure they get the accurate information from the latest finalized block, then they can decide what to do next instantly. More details of design, please to refer [BEP-126](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP126.md)
+Finality is critical for blockchain security, once the block is finalized, it wouldn’t be reverted anymore. The fast finality feature is very useful, the users can make sure they get the accurate information from the latest finalized block, then they can decide what to do next instantly. More details of design, please refer to [BEP-126](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP126.md)
 
-Before the coming Plato upgrade,to secure as much as BC, BSC users are encouraged to wait until receiving blocks sealed by more than ⅔*N+1 different validators. In that way, the BSC can be trusted at a similar security level to BC and can tolerate less than ⅓\*N Byzantine validators.With 21 validators, if the block time is 3 seconds, the ⅔\*N+1 different validator seals will need a time period of (⅔\*21+1)\*3 = 45 seconds. Any critical applications for BSC may have to wait for ⅔\*N+1 to ensure a relatively secure finality. With above enhancement by slashing mechanism, ½\*N+1 or even fewer blocks are enough as confirmation for most transactions.
+With Fast Finality enabled (since the Plato upgrade), the chain is finalized within two blocks if ⅔*N or more validators vote normally. At the current block time of **0.45 seconds**, this means finality is achieved in approximately **1.125 seconds**. If Fast Finality votes are insufficient, the chain falls back to probabilistic finality where more confirmations increase safety.
 
-After the coming Plato upgrade, the feature `Fast Finality` will be enabled. The chain will be finalized within two blocks if ⅔*N or more validators vote normally, otherwise the chain has a fixed number of blocks to reach probabilistic finality as before.
+For applications that need guaranteed finality, the `finalized` block tag in JSON-RPC calls (e.g., `eth_getBlockByNumber`) can be used to query only finalized blocks.
 
 ## Reward
-All the BSC validators in the current validator set will be rewarded with transaction fees in BNB. As BNB is not an inflationary token, there will be no mining rewards as what Bitcoin and Ethereum network generate, and the gas fee is the major reward for validators. After the coming Plato upgrade, part of the fees collected will be used as reward for finality voting. As BNB is also utility tokens with other use cases, delegators and validators will still enjoy other benefits of holding BNB.
+All the BSC validators in the current validator set will be rewarded with transaction fees in BNB. As BNB is not an inflationary token, there will be no mining rewards as what Bitcoin and Ethereum network generate, and the gas fee is the major reward for validators. Part of the fees collected is used as reward for finality voting. As BNB is also utility tokens with other use cases, delegators and validators will still enjoy other benefits of holding BNB.
 
 The reward for validators is the fees collected from transactions in each block. Validators can decide how much to give back to the delegators who stake their BNB to them, in order to attract more staking. Every validator will take turns to produce the blocks in the same probability (if they stick to 100% liveness), thus, in the long run, all the stable validators may get a similar size of the reward. Meanwhile, the stakes on each validator may be different, so this brings a counter-intuitive situation that more users trust and delegate to one validator, they potentially get less reward. So rational delegators will tend to delegate to the one with fewer stakes as long as the validator is still trustful (insecure validator may bring slashable risk). In the end, the stakes on all the validators will have less variation. This will actually prevent the stake concentration and "winner wins forever" problem seen on some other networks.
 

--- a/docs/bnb-smart-chain/overview.md
+++ b/docs/bnb-smart-chain/overview.md
@@ -12,7 +12,7 @@ BNB Smart Chain (BSC) is a high-performance blockchain network. Officially launc
    BSC is fully compatible with the Ethereum Virtual Machine (EVM), enabling developers to port their Ethereum-based DApps and DeFi projects to BSC with minimal modifications. This compatibility extends to the use of popular Ethereum tools and applications, such as TrustWallet, MetaMask, Truffle, and Remix.
 
 2. **Low Transaction Fees and Fast Block Times:**
-   One of BSC's primary advantages is its low transaction fees. As of early 2024, the average transaction fee on BSC is around $0.10, significantly lower compared to Ethereum's average fee of $10-$20 during periods of high network congestion. Additionally, BSC block time of approximately is 3 seconds, ensuring rapid transaction confirmations and an overall smoother user experience.
+   One of BSC's primary advantages is its low transaction fees. With the network-wide adoption of a **0.05 Gwei** standard gas price, typical transaction fees on BSC are around **$0.005** or less, significantly lower compared to Ethereum. BSC's block time is approximately **0.45 seconds** (reduced from 3s through the Lorentz, Maxwell, and Fermi hardforks), ensuring near-instant transaction confirmations and an overall smoother user experience.
 
 3. **Robust Ecosystem and Growing Adoption:**
    Since its inception, BSC has seen rapid growth in its ecosystem. By May 2024, BSC supports over 1,500 DApps, with popular platforms such as PancakeSwap, Venus, and BakerySwap leading the charge. The total value locked (TVL) in BSC-based DeFi protocols exceeds $20 billion, reflecting its substantial market adoption and user trust.

--- a/docs/bnb-smart-chain/staking/user-guide.md
+++ b/docs/bnb-smart-chain/staking/user-guide.md
@@ -122,7 +122,7 @@ Use this JavaScript example to query a validator's total pooled BNB:
 ```javascript
 import { ethers } from 'ethers';
 
-const provider = new ethers.JsonRpcProvider('https://bsc-dataseed.binance.org');
+const provider = new ethers.JsonRpcProvider('https://bsc-dataseed.bnbchain.org');
 const OPERATOR = '0x...'; // validator operator address
 
 const hub = new ethers.Contract('0x0000000000000000000000000000000000002002',


### PR DESCRIPTION
Removed reference to the discord faucet bot as this has been sunset since September 2025  and the Superintern AI bot is using this information in its knowledge base to misinform users on where to go when accessing testnet tokens 