### PR TITLE
Replace Blocksmith with JetBuilder in MEV guide

### DIFF
--- a/docs/bnb-smart-chain/validator/mev/user-guide.md
+++ b/docs/bnb-smart-chain/validator/mev/user-guide.md
@@ -62,7 +62,7 @@ While free private RPCs offer a good level of protection, you can opt for even s
 
 | Role                                                         | Status and Comments                                          |
 | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| 5 Builders (Private privacy protecting RPC service providers) | <ul><li>[BloxRoute](https://bloxroute.com/products/protected-transactions/)</li><li>[Blocksmith](https://docs.blocksmith.org/bsc-builder/private-rpc)</li><li>[Nodereal](https://docs.nodereal.io/reference/bsc-bundle-service-api#overview)</li><li>[Blockrazor](https://blockrazor.gitbook.io/blockrazor/mev-service/bsc)</li><li>[Puissant](https://docs.48.club/)</li></ul> |
+| 5 Builders (Private privacy protecting RPC service providers) | <ul><li>[BloxRoute](https://bloxroute.com/products/protected-transactions/)</li><li>[JetBuilder](https://jetbldr.xyz/api_bsc/)</li><li>[Nodereal](https://docs.nodereal.io/reference/bsc-bundle-service-api#overview)</li><li>[Blockrazor](https://blockrazor.gitbook.io/blockrazor/mev-service/bsc)</li><li>[Puissant](https://docs.48.club/)</li></ul> |
 
 There are two aspects that may impact the transaction inclusion speed. 
 


### PR DESCRIPTION
Update docs/bnb-smart-chain/validator/mev/user-guide.md to replace the Blocksmith entry with JetBuilder in the list of private privacy-protecting RPC service providers and update the provider link to JetBuilder's API. Keeps the provider list up to date.