### PR TITLE
Add Privacy at Scale docs and nav

### DIFF
--- a/docs/developer-kit/bnbagent-sdk/architecture.md
+++ b/docs/developer-kit/bnbagent-sdk/architecture.md
@@ -1,16 +1,16 @@
 ---
-title: BNBAgent SDK Architecture
+title: BNB Agent SDK Architecture
 ---
 
 # Architecture
 
-This document describes the high-level architecture of the BNBAgent SDK.
+This document describes the high-level architecture of the BNB Agent SDK.
 If you want to familiarize yourself with the codebase, this is a good place
 to start.
 
 ## Bird's Eye View
 
-BNBAgent SDK is a Python toolkit for building **on-chain AI agents** on
+BNB Agent SDK is a Python toolkit for building **on-chain AI agents** on
 BNB Chain. It provides wallet management, a plugin module system, off-chain
 storage abstraction, and built-in support for the following protocols:
 

--- a/docs/developer-kit/bnbagent-sdk/configuration.md
+++ b/docs/developer-kit/bnbagent-sdk/configuration.md
@@ -1,5 +1,5 @@
 ---
-title: BNBAgent SDK Configuration
+title: BNB Agent SDK Configuration
 ---
 
 ## Configuration Reference
@@ -32,6 +32,6 @@ Commerce settlement assets are resolved at runtime from the deployed kernel — 
 
 See [.env.example](https://github.com/bnb-chain/bnbagent-sdk/blob/main/.env.example) in the repository for the full surface with inline comments.
 
-[← BNBAgent SDK overview](index.md)
+[← BNB Agent SDK overview](index.md)
 
 ---

--- a/docs/developer-kit/bnbagent-sdk/examples.md
+++ b/docs/developer-kit/bnbagent-sdk/examples.md
@@ -1,5 +1,5 @@
 ---
-title: BNBAgent SDK Examples
+title: BNB Agent SDK Examples
 ---
 
 Runnable scripts in the [bnbagent-sdk](https://github.com/bnb-chain/bnbagent-sdk) repository.
@@ -10,4 +10,4 @@ Runnable scripts in the [bnbagent-sdk](https://github.com/bnb-chain/bnbagent-sdk
 | [examples/voter/](https://github.com/bnb-chain/bnbagent-sdk/tree/main/examples/voter/) | Voter | `voteReject` script + `Disputed` event watcher for whitelisted voters. |
 | [examples/agent-server/](https://github.com/bnb-chain/bnbagent-sdk/tree/main/examples/agent-server/) | Provider | FastAPI agent that searches blockchain news via DuckDuckGo. Demonstrates `create_erc8183_app()`, the funded-job poll loop, and ERC-8004 registration. |
 
-[← BNBAgent SDK overview](index.md)
+[← BNB Agent SDK overview](index.md)

--- a/docs/developer-kit/bnbagent-sdk/index.md
+++ b/docs/developer-kit/bnbagent-sdk/index.md
@@ -1,12 +1,12 @@
 ---
-title: BNBAgent SDK
+title: BNB Agent SDK
 ---
 
-# BNBAgent SDK
+# BNB Agent SDK
 
 Python SDK for building on-chain AI agents on BNB Chain — register identities, negotiate, accept jobs, deliver work, and get paid trustlessly through on-chain escrow.
 
-BNBAgent SDK provides two core capabilities:
+BNB Agent SDK provides two core capabilities:
 
 - **ERC-8004 (Agent Identity)** — Register your AI agent on-chain with a unique identity token, manage wallets, and make your agent discoverable. Registration is gas-free on BSC Testnet and BSC Mainnet via MegaFuel paymaster sponsorship.
 - **ERC-8183 Protocol (Agentic Commerce)** — A three-layer agentic commerce stack (AgenticCommerce kernel + EvaluatorRouter + OptimisticPolicy) where agents negotiate pricing, accept jobs, deliver work, and settle payment automatically. Uses optimistic settlement: silence past the dispute window is implicit approval, and clients can dispute within the window to trigger a whitelisted-voter quorum reject.

--- a/docs/developer-kit/bnbagent-sdk/networks.md
+++ b/docs/developer-kit/bnbagent-sdk/networks.md
@@ -1,5 +1,5 @@
 ---
-title: BNBAgent SDK Networks & Contracts
+title: BNB Agent SDK Networks & Contracts
 ---
 
 ## Network & Contracts
@@ -24,4 +24,4 @@ The SDK resolves commerce-related addresses at runtime from its network presets 
 
 **ERC-8004 registration**: Gas-sponsored on BSC Testnet and BSC Mainnet via [MegaFuel paymaster](https://docs.nodereal.io/docs/megafuel-overview).
 
-[← BNBAgent SDK overview](index.md)
+[← BNB Agent SDK overview](index.md)

--- a/docs/developer-kit/bnbagent-sdk/quickstart.md
+++ b/docs/developer-kit/bnbagent-sdk/quickstart.md
@@ -1,5 +1,5 @@
 ---
-title: BNBAgent SDK Quickstart
+title: BNB Agent SDK Quickstart
 ---
 
 ## Quick Start: Register an Agent (ERC-8004)

--- a/docs/developer-kit/bnbagent-sdk/security.md
+++ b/docs/developer-kit/bnbagent-sdk/security.md
@@ -1,5 +1,5 @@
 ---
-title: BNBAgent SDK Security
+title: BNB Agent SDK Security
 ---
 
 ## Security

--- a/docs/developer-kit/bnbagent-sdk/troubleshooting.md
+++ b/docs/developer-kit/bnbagent-sdk/troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-title: BNBAgent SDK Troubleshooting
+title: BNB Agent SDK Troubleshooting
 ---
 
 ## Troubleshooting

--- a/docs/developer-kit/bnbchain-studio/architecture.md
+++ b/docs/developer-kit/bnbchain-studio/architecture.md
@@ -1,10 +1,10 @@
 ---
-title: BNBChain Studio Architecture
+title: BNB Agent Studio Architecture
 ---
 
 # Architecture
 
-BNBChain Studio wraps the [BNBAgent SDK](../bnbagent-sdk/index.md) with scaffolding, safety controls, and IDE integration. A v1 seller project is **two deployable artifacts** on top of a **six-layer stack**.
+BNB Agent Studio wraps the [BNB Agent SDK](../bnbagent-sdk/index.md) with scaffolding, safety controls, and IDE integration. A v1 seller project is **two deployable artifacts** on top of a **six-layer stack**.
 
 ## Six-layer stack
 
@@ -155,8 +155,8 @@ Buyer                    Layer B (Service)              Layer A (Agent)         
 
 ## Further reading
 
-- [BNBAgent SDK architecture](../bnbagent-sdk/architecture.md) — protocol module system
+- [BNB Agent SDK architecture](../bnbagent-sdk/architecture.md) — protocol module system
 - [GitHub — architecture.md](https://github.com/bnb-chain/bnbagent-studio/blob/main/docs/design/architecture.md) — full design document
 - [GitHub — decisions.md](https://github.com/bnb-chain/bnbagent-studio/blob/main/docs/design/decisions.md) — decision records
 
-[← BNBChain Studio overview](index.md)
+[← BNB Agent Studio overview](index.md)

--- a/docs/developer-kit/bnbchain-studio/cli-reference.md
+++ b/docs/developer-kit/bnbchain-studio/cli-reference.md
@@ -1,5 +1,5 @@
 ---
-title: BNBChain Studio CLI Reference
+title: BNB Agent Studio CLI Reference
 ---
 
 # CLI Reference
@@ -112,4 +112,4 @@ from .managed_model import X     # wrong — bag doctor warns
 
 Full capability reference: [GitHub — reference.md](https://github.com/bnb-chain/bnbagent-studio/blob/main/docs/reference.md)
 
-[← BNBChain Studio overview](index.md)
+[← BNB Agent Studio overview](index.md)

--- a/docs/developer-kit/bnbchain-studio/configuration.md
+++ b/docs/developer-kit/bnbchain-studio/configuration.md
@@ -1,10 +1,10 @@
 ---
-title: BNBChain Studio Configuration
+title: BNB Agent Studio Configuration
 ---
 
 # Configuration
 
-BNBChain Studio projects use two config files per layer plus environment variables. The workspace root holds the keystore but **no** `studio.toml` or `.env.local`.
+BNB Agent Studio projects use two config files per layer plus environment variables. The workspace root holds the keystore but **no** `studio.toml` or `.env.local`.
 
 ## Two `studio.toml` files
 
@@ -110,4 +110,4 @@ bag env set WALLET_PASSWORD <password> --project-root app/agent
 bag env get WALLET_PASSWORD --project-root app/agent
 ```
 
-[← BNBChain Studio overview](index.md)
+[← BNB Agent Studio overview](index.md)

--- a/docs/developer-kit/bnbchain-studio/demo.md
+++ b/docs/developer-kit/bnbchain-studio/demo.md
@@ -1,10 +1,10 @@
 ---
-title: BNBChain Studio Demo
+title: BNB Agent Studio Demo
 ---
 
 # Demo — weather-forecast seller (end to end)
 
-This walkthrough follows the full BNBChain Studio path for a single example: a **weather-forecast seller** on BSC testnet. You install the CLI, scaffold the agent with your AI IDE, set up a wallet, fund it, activate an LLM, run locally, negotiate a sale, register on-chain, and deploy.
+This walkthrough follows the full BNB Agent Studio path for a single example: a **weather-forecast seller** on BSC testnet. You install the CLI, scaffold the agent with your AI IDE, set up a wallet, fund it, activate an LLM, run locally, negotiate a sale, register on-chain, and deploy.
 
 Commands and behavior match the [bnbagent-studio](https://github.com/bnb-chain/bnbagent-studio) repository — see the [weather seller example](https://github.com/bnb-chain/bnbagent-studio#-example-a-weather-forecast-seller-end-to-end) in the README for the canonical reference.
 
@@ -607,4 +607,4 @@ All commands and skills referenced here live in [github.com/bnb-chain/bnbagent-s
 - [User guide](https://github.com/bnb-chain/bnbagent-studio/blob/main/docs/guides/user-guide.md)
 - [Capabilities reference](https://github.com/bnb-chain/bnbagent-studio/blob/main/docs/reference.md)
 
-[← BNBChain Studio overview](index.md)
+[← BNB Agent Studio overview](index.md)

--- a/docs/developer-kit/bnbchain-studio/deployment.md
+++ b/docs/developer-kit/bnbchain-studio/deployment.md
@@ -1,5 +1,5 @@
 ---
-title: BNBChain Studio Deployment
+title: BNB Agent Studio Deployment
 ---
 
 # Deployment
@@ -124,4 +124,4 @@ bag erc8004 show
 | Service `:8003` | EC2 `/apex/*` |
 | `STORAGE_LOCAL_PATH` | S3 / IPFS |
 
-[← BNBChain Studio overview](index.md)
+[← BNB Agent Studio overview](index.md)

--- a/docs/developer-kit/bnbchain-studio/index.md
+++ b/docs/developer-kit/bnbchain-studio/index.md
@@ -1,12 +1,12 @@
 ---
-title: BNBChain Studio
+title: BNB Agent Studio
 ---
 
-# BNBChain Studio
+# BNB Agent Studio
 
-Scaffold, run, and deploy a **two-layer blockchain seller** on BNB Chain. BNBChain Studio (`bnbagent-studio`) lets you describe what you want in Claude Code or Cursor; the studio emits a working agent project that **you own**, then helps you develop, debug, and deploy it.
+Scaffold, run, and deploy a **two-layer blockchain seller** on BNB Chain. BNB Agent Studio (`bnbagent-studio`) lets you describe what you want in Claude Code or Cursor; the studio emits a working agent project that **you own**, then helps you develop, debug, and deploy it.
 
-A seller agent earns on-chain by offering services over **ERC-8004** (identity) + **ERC-8183** (commerce) + **x402** (payments), built on the [BNBAgent SDK](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/).
+A seller agent earns on-chain by offering services over **ERC-8004** (identity) + **ERC-8183** (commerce) + **x402** (payments), built on the [BNB Agent SDK](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/).
 
 > **v0.0.1 is seller-only.** The CLI (`bag`), runtime library (`bnbagent_studio_core`), read-only MCP server, and IDE skills ship today. Buyer product flows and a hosted console are deferred to v2.
 
@@ -50,16 +50,16 @@ AWS Bedrock AgentCore is invoke-only (no public HTTP routes, no background poll 
 - **Layer A — the Agent** (`app/agent/` → AWS Bedrock AgentCore): the LLM, memory, tools, and **sole key-holder/signer**. Invoked on action envelopes (`quote` / `fulfill` / `settle`). All signing is fixed entrypoint code — never an LLM-callable tool.
 - **Layer B — the ERC-8183 Service** (`app/service/` → EC2/Fargate): a public, long-running, **keyless** container — `/negotiate` ingress, funded-job poller, and `InvokeAgentRuntime` client. Holds no key, runs no LLM, never signs.
 
-## Relationship to BNBAgent SDK
+## Relationship to BNB Agent SDK
 
 | Layer | Package | Role |
 |-------|---------|------|
-| Protocol | [bnbagent](https://pypi.org/project/bnbagent/) (BNBAgent SDK) | ERC-8004, ERC-8183, wallet ABC — pure protocol clients |
+| Protocol | [bnbagent](https://pypi.org/project/bnbagent/) (BNB Agent SDK) | ERC-8004, ERC-8183, wallet ABC — pure protocol clients |
 | Studio core | `bnbagent_studio_core` | Config, workflows, signing policy, audit log |
 | Studio surface | `bag` CLI + MCP + skills + recipes | Scaffolding, ops, IDE integration |
 | Your code | `app/agent/*`, `app/service/*` | Emitted by recipes; you own and edit freely |
 
-Use BNBAgent SDK directly when you want full control over protocol integration. Use BNBChain Studio when you want scaffolding, IDE skills, a two-layer deploy path, and safety defaults out of the box.
+Use BNB Agent SDK directly when you want full control over protocol integration. Use BNB Agent Studio when you want scaffolding, IDE skills, a two-layer deploy path, and safety defaults out of the box.
 
 ## Prerequisites
 

--- a/docs/developer-kit/bnbchain-studio/quickstart.md
+++ b/docs/developer-kit/bnbchain-studio/quickstart.md
@@ -1,5 +1,5 @@
 ---
-title: BNBChain Studio Quickstart
+title: BNB Agent Studio Quickstart
 ---
 
 # Quickstart
@@ -146,6 +146,6 @@ The skills run the right `bag` commands and edit your files. The commands above 
 - [Demo](demo.md) — full end-to-end weather-forecast seller walkthrough
 - [Architecture](architecture.md) — how the six layers fit together
 - [Configuration](configuration.md) — `studio.toml` sections and env vars
-- [BNBAgent SDK quickstart](../bnbagent-sdk/quickstart.md) — protocol-level integration
+- [BNB Agent SDK quickstart](../bnbagent-sdk/quickstart.md) — protocol-level integration
 
-[← BNBChain Studio overview](index.md)
+[← BNB Agent Studio overview](index.md)

--- a/docs/developer-kit/bnbchain-studio/security.md
+++ b/docs/developer-kit/bnbchain-studio/security.md
@@ -1,10 +1,10 @@
 ---
-title: BNBChain Studio Security
+title: BNB Agent Studio Security
 ---
 
 # Security
 
-BNBChain Studio is designed around five commitments. The security model follows from architectural boundaries, not optional settings.
+BNB Agent Studio is designed around five commitments. The security model follows from architectural boundaries, not optional settings.
 
 ## Core commitments
 
@@ -94,4 +94,4 @@ Deploying provisions resources in **your** AWS account. Published IAM reference 
 - Keep the Service zip free of Agent secrets — `bag deploy package` enforces this
 - Review `[wallet.signing]` before extending beyond default EIP-3009 allowlist
 
-[← BNBChain Studio overview](index.md)
+[← BNB Agent Studio overview](index.md)

--- a/docs/developer-kit/bnbchain-studio/troubleshooting.md
+++ b/docs/developer-kit/bnbchain-studio/troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-title: BNBChain Studio Troubleshooting
+title: BNB Agent Studio Troubleshooting
 ---
 
 # Troubleshooting
@@ -115,7 +115,7 @@ Readiness check `C4` warns if the keystore is still inside `app/agent/`. Move it
 
 ## Related
 
-- [BNBAgent SDK troubleshooting](../bnbagent-sdk/troubleshooting.md) — protocol-level errors
+- [BNB Agent SDK troubleshooting](../bnbagent-sdk/troubleshooting.md) — protocol-level errors
 - [Security](security.md) — signing policy and keystore posture
 
-[← BNBChain Studio overview](index.md)
+[← BNB Agent Studio overview](index.md)

--- a/docs/developer-kit/index.md
+++ b/docs/developer-kit/index.md
@@ -8,8 +8,8 @@ Index of official BNB Chain tools. Full SDK guides live in each product folder b
 
 | Product | Chains | Card |
 |---------|--------|------|
-| **BNBAgent SDK** | BSC, opBNB | [bnbagent-sdk/](bnbagent-sdk/index.md) |
-| **BNBChain Studio** | BSC | [bnbchain-studio/](bnbchain-studio/index.md) |
+| **BNB Agent SDK** | BSC, opBNB | [bnbagent-sdk/](bnbagent-sdk/index.md) |
+| **BNB Agent Studio** | BSC | [bnbchain-studio/](bnbchain-studio/index.md) |
 | **Greenfield SDK** | Greenfield | [greenfield-sdk/](greenfield-sdk/index.md) |
 | **MCP & Ask AI** | BSC, opBNB, Greenfield (bnbchain-mcp); BSC docs (Ask AI) | [mcp/](mcp/index.md) |
 | **MPP SDK** | BSC, opBNB | [mpp-sdk/](mpp-sdk/index.md) |

--- a/docs/developer-kit/index.md
+++ b/docs/developer-kit/index.md
@@ -13,3 +13,4 @@ Index of official BNB Chain tools. Full SDK guides live in each product folder b
 | **Greenfield SDK** | Greenfield | [greenfield-sdk/](greenfield-sdk/index.md) |
 | **MCP & Ask AI** | BSC, opBNB, Greenfield (bnbchain-mcp); BSC docs (Ask AI) | [mcp/](mcp/index.md) |
 | **MPP SDK** | BSC, opBNB | [mpp-sdk/](mpp-sdk/index.md) |
+| **Privacy at Scale** | BSC | [privacy-at-scale/](privacy-at-scale/index.md) |

--- a/docs/developer-kit/privacy-at-scale/index.md
+++ b/docs/developer-kit/privacy-at-scale/index.md
@@ -34,17 +34,7 @@ Undercollateralized lending has been the “holy grail” of DeFi, but it requir
 
 **Application:** This allows users to access better interest rates or higher leverage based on their real-world financial standing without doxxing their identity to the lending protocol.
 
-### 3. BAP-674: standardizing the private ledger
-
-Fragmented privacy solutions are a barrier to institutional adoption. [Polyhedra](https://polyhedra.network/)’s BAP-674 protocol acts as the “TCP/IP” for private transactions on BNB Chain, creating a unified language for how tokens move anonymously.
-
-**Unified API:** It provides a standardized interface for developers to integrate anonymous transfers into their dApps.
-
-**Interoperability:** It ensures that a “private” token on one side of the ecosystem remains private and verifiable when moved to another compliant platform.
-
-**Compliance integration:** By defining a standard, BAP-674 makes it easier for third-party compliance software to plug into the ecosystem without compromising the underlying ZK-circuit integrity.
-
-### 4. Zama and FHE: the “blind computation” frontier
+### 3. Zama and FHE: the “blind computation” frontier
 
 While ZK-proofs are excellent for proving a statement is true, Fully Homomorphic Encryption (FHE) allows for actual computation on encrypted data. BNB Chain’s collaboration with [Zama](https://www.zama.org/) marks the transition into the era of **blind computation**.
 
@@ -58,7 +48,6 @@ While ZK-proofs are excellent for proving a statement is true, Fully Homomorphic
 |----------|-------------|---------------|--------------|--------|
 | **Intelligent Privacy Pool** (Brevis / 0xbow) | Institutions requiring compliant confidentiality | Institutional private transfers, fair prediction markets, compliant fund mixing | 1. Deposit assets → 2. Prove eligibility via on-chain provenance → 3. Withdraw to unlinked address if in “Association Set” | **Launched** (early 2026) |
 | **ZKredit** (Brevis / Primus) | DeFi lenders and credit-gated protocols | Undercollateralized DeFi lending, credit-based RWA access, reputation-gated dApps | 1. Generate local ZK proof of account history / balance → 2. Record on-chain attestation → 3. dApp queries registry | **In development** — ListaDAO loan product planned as first proof of concept; launch date TBD |
-| **BAP-674** (Polyhedra) | Developers and institutional payment rails | Standardized institutional payments, multi-asset privacy transfers, audit-ready anonymous assets | 1. Initiate standard transfer → 2. zkSNARK verification of state transition → 3. Recipient receives assets with hidden amounts and addresses | **In development** |
 | **FHE layer** (Zama) | Banks, asset managers, RWA issuers | Bank-grade RWA tokenization (stocks, bonds), dark pools, encrypted governance, private payroll | 1. Wrap existing tokens 1:1 into confidential versions → 2. Perform computations on encrypted data → 3. Network verifies validity via blind computation | **In development** — timeline TBD |
 
 ## Strategic roadmap: toward a native privacy layer
@@ -79,7 +68,7 @@ BNB Chain’s long-term goal is to move beyond middleware and integrate privacy 
 
 ## Conclusion
 
-BNB Chain offers a multi-layered privacy stack suitable for the world's largest financial institutions. From standardizing transfers with BAP-674 to building a native, high-performance privacy layer for the next-generation trading chain, BNB Chain is establishing privacy as a core infrastructure primitive. For institutions, this stack provides a path to unlocking traditional financial value on a high-throughput, compliant public ledger.
+BNB Chain offers a multi-layered privacy stack suitable for the world's largest financial institutions. From compliant privacy pools and credit attestations to a native, high-performance privacy layer on the next-generation trading chain, BNB Chain is establishing privacy as a core infrastructure primitive. For institutions, this stack provides a path to unlocking traditional financial value on a high-throughput, compliant public ledger.
 
 ## References
 

--- a/docs/developer-kit/privacy-at-scale/index.md
+++ b/docs/developer-kit/privacy-at-scale/index.md
@@ -1,0 +1,92 @@
+---
+title: Privacy at Scale — ZKP and FHE for Institutions
+---
+
+# BNB Chain Privacy at Scale: ZKP and FHE for Institutions
+
+## Executive summary: privacy as core infrastructure
+
+While the transparency of blockchain technology is a foundational element of trust, for institutional financial participants it remains a significant barrier to large-scale adoption. Institutions must operate within strict legal frameworks regarding data privacy, commercial secrets, and fiduciary duties. The exposure of large transactions, account balances, and strategy-revealing trade flows on a public ledger can lead to front-running, MEV (Maximal Extractable Value) exploitation, and regulatory breaches.
+
+BNB Chain is addressing this by building an ecosystem focused on **programmable confidentiality**. By integrating Zero-Knowledge Proofs (ZKP) and Fully Homomorphic Encryption (FHE), BNB Chain is defining institutional-grade infrastructure capable of supporting regulated finance, Real-World Asset (RWA) tokenization, and complex institutional DeFi strategies.
+
+## Core technology deep-dive
+
+By integrating Zero-Knowledge (ZK) proofs and Fully Homomorphic Encryption (FHE), BNB Chain is moving beyond simple “privacy coins” toward a sophisticated infrastructure where data is verified without ever being seen.
+
+### 1. Intelligent Privacy Pool: the end of “blind” compliance
+
+The Intelligent Privacy Pool, a joint venture between [Brevis](https://brevis.network/) and [0xbow](https://0xbow.io/), represents the first physical implementation of this privacy standard. Launched in early 2026, it addresses the “tainted funds” dilemma that has plagued DeFi.
+
+**Mechanism:** It utilizes the Brevis ZK Data Coprocessor to scan a user’s historical on-chain activity.
+
+**The innovation:** Instead of revealing the entire transaction history to a centralized auditor, the system generates a ZK-proof confirming that the funds did not originate from sanctioned addresses or known exploits.
+
+**Outcome:** Users maintain total privacy from the public, while the protocol remains compliant with global Anti-Money Laundering (AML) standards.
+
+### 2. ZKredit: the privacy-preserving identity layer
+
+Undercollateralized lending has been the “holy grail” of DeFi, but it requires knowing the borrower’s creditworthiness — a process that usually kills privacy. [ZKredit](https://www.bnbchain.org/en/blog/zkredit-bringing-real-world-credit-identity-onchain-privately) from Brevis and Primus solves this by bridging the gap between financial reputation and Web3 anonymity.
+
+**Local proof generation:** Using a browser extension or secure wallet environment, ZKredit accesses off-chain data, such as Centralized Exchange (CEX) account age, VIP tiers, or even traditional bank balances.
+
+**Data sovereignty:** The raw data stays on the user’s device. Only a cryptographic “proof of credit” is uploaded to the blockchain.
+
+**Application:** This allows users to access better interest rates or higher leverage based on their real-world financial standing without doxxing their identity to the lending protocol.
+
+### 3. BAP-674: standardizing the private ledger
+
+Fragmented privacy solutions are a barrier to institutional adoption. [Polyhedra](https://polyhedra.network/)’s BAP-674 protocol acts as the “TCP/IP” for private transactions on BNB Chain, creating a unified language for how tokens move anonymously.
+
+**Unified API:** It provides a standardized interface for developers to integrate anonymous transfers into their dApps.
+
+**Interoperability:** It ensures that a “private” token on one side of the ecosystem remains private and verifiable when moved to another compliant platform.
+
+**Compliance integration:** By defining a standard, BAP-674 makes it easier for third-party compliance software to plug into the ecosystem without compromising the underlying ZK-circuit integrity.
+
+### 4. Zama and FHE: the “blind computation” frontier
+
+While ZK-proofs are excellent for proving a statement is true, Fully Homomorphic Encryption (FHE) allows for actual computation on encrypted data. BNB Chain’s collaboration with [Zama](https://www.zama.org/) marks the transition into the era of **blind computation**.
+
+**How it works:** In a standard smart contract, the state (who owns what) is public. With FHE, the contract can process a trade — calculating new balances and updating the ledger — while the values remain encrypted.
+
+**Institutional shielding:** For the first time, institutions can manage massive portfolios on-chain without competitors seeing their specific holdings, entry prices, or trade flows, all while remaining visible to specific regulators through “viewing keys.”
+
+## Solutions overview
+
+| Solution | Target user | Key use cases | User journey | Status |
+|----------|-------------|---------------|--------------|--------|
+| **Intelligent Privacy Pool** (Brevis / 0xbow) | Institutions requiring compliant confidentiality | Institutional private transfers, fair prediction markets, compliant fund mixing | 1. Deposit assets → 2. Prove eligibility via on-chain provenance → 3. Withdraw to unlinked address if in “Association Set” | **Launched** (early 2026) |
+| **ZKredit** (Brevis / Primus) | DeFi lenders and credit-gated protocols | Undercollateralized DeFi lending, credit-based RWA access, reputation-gated dApps | 1. Generate local ZK proof of account history / balance → 2. Record on-chain attestation → 3. dApp queries registry | **In development** — ListaDAO loan product planned as first proof of concept; launch date TBD |
+| **BAP-674** (Polyhedra) | Developers and institutional payment rails | Standardized institutional payments, multi-asset privacy transfers, audit-ready anonymous assets | 1. Initiate standard transfer → 2. zkSNARK verification of state transition → 3. Recipient receives assets with hidden amounts and addresses | **In development** |
+| **FHE layer** (Zama) | Banks, asset managers, RWA issuers | Bank-grade RWA tokenization (stocks, bonds), dark pools, encrypted governance, private payroll | 1. Wrap existing tokens 1:1 into confidential versions → 2. Perform computations on encrypted data → 3. Network verifies validity via blind computation | **In development** — timeline TBD |
+
+## Strategic roadmap: toward a native privacy layer
+
+BNB Chain’s long-term goal is to move beyond middleware and integrate privacy as a foundational, protocol-level layer. The 2026–2028 roadmap outlines a transformation toward an **encrypted-by-default** architecture.
+
+**Native ZK privacy modules:** BNB Chain plans to implement native zero-knowledge modules within its core architecture to support secure settlement and compliant confidentiality for all high-frequency transactions.
+
+**Next-generation trading chain:** Between 2026 and 2028, BNB Chain is designing a specialized chain targeting ~1 million TPS and 150ms finality. This infrastructure will natively support advanced scenarios across AI, privacy, and RWA, offering a Web2-level experience with cryptographic security.
+
+**The “HTTPZ” vision:** Drawing an analogy to the internet’s transition from HTTP to HTTPS, BNB Chain aims for HTTPZ — a state where privacy is the default infrastructure setting rather than an optional add-on.
+
+## Institutional value proposition
+
+**Capital efficiency:** ZKredit enables risk-tiered lending products, allowing institutions to participate in undercollateralized credit markets based on verified reputations.
+
+**Seamless compliance:** Solutions are designed to be private by default, compliant when needed — allowing for selective disclosure to regulators without creating public data leaks.
+
+## Conclusion
+
+BNB Chain offers a multi-layered privacy stack suitable for the world's largest financial institutions. From standardizing transfers with BAP-674 to building a native, high-performance privacy layer for the next-generation trading chain, BNB Chain is establishing privacy as a core infrastructure primitive. For institutions, this stack provides a path to unlocking traditional financial value on a high-throughput, compliant public ledger.
+
+## References
+
+- [Zama first look: bringing compliant confidentiality on-chain](https://www.figment.io/insights/zama-first-look-bringing-compliant-confidentiality-on-chain/) — Figment
+- [What is Zama (ZAMA)?](https://www.binance.com/en/academy/articles/what-is-zama) — Binance Academy
+- [Brevis x BNB Chain: redefining privacy infrastructure for Web3](https://blog.brevis.network/2026/01/15/brevis-x-bnb-chain-redefining-privacy-infrastructure-for-web3/) — Brevis
+- [ZKredit: bringing real-world credit identity onchain, privately](https://www.bnbchain.org/en/blog/zkredit-bringing-real-world-credit-identity-onchain-privately) — BNB Chain Blog
+- [ZKredit launches on BNB Chain to bridge TradFi credit data with DeFi lending](https://www.mexc.com/news/980797) — MEXC News
+
+[← Developer Kit overview](../index.md)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -234,7 +234,7 @@
   - [Architecture](https://docs.bnbchain.org/developer-kit/mpp-sdk/architecture/): Wire schema and verifiers.
   - [Replay store](https://docs.bnbchain.org/developer-kit/mpp-sdk/replay-store/): Durable atomic replay protection.
   - [Examples](https://docs.bnbchain.org/developer-kit/mpp-sdk/examples/): charge-server, charge-demo, bnb-wire-demo.
-- **MCP & Ask AI**
+- [Privacy at Scale](https://docs.bnbchain.org/developer-kit/privacy-at-scale/): ZKP and FHE institutional privacy stack — Intelligent Privacy Pool, ZKredit, BAP-674, and Zama FHE.
   - [Overview](https://docs.bnbchain.org/developer-kit/mcp/): bnbchain-mcp server for on-chain tools and IDE integration.
   - [Ask AI](https://docs.bnbchain.org/developer-kit/ask-ai/): Read-only MCP doc search for BNB Chain.
   - [VS Code guide](https://docs.bnbchain.org/developer-kit/ask-ai/vs-code-guide/): Step-by-step Ask AI setup in Visual Studio Code.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -234,7 +234,7 @@
   - [Architecture](https://docs.bnbchain.org/developer-kit/mpp-sdk/architecture/): Wire schema and verifiers.
   - [Replay store](https://docs.bnbchain.org/developer-kit/mpp-sdk/replay-store/): Durable atomic replay protection.
   - [Examples](https://docs.bnbchain.org/developer-kit/mpp-sdk/examples/): charge-server, charge-demo, bnb-wire-demo.
-- [Privacy at Scale](https://docs.bnbchain.org/developer-kit/privacy-at-scale/): ZKP and FHE institutional privacy stack — Intelligent Privacy Pool, ZKredit, BAP-674, and Zama FHE.
+- [Privacy at Scale](https://docs.bnbchain.org/developer-kit/privacy-at-scale/): ZKP and FHE institutional privacy stack — Intelligent Privacy Pool, ZKredit, and Zama FHE.
   - [Overview](https://docs.bnbchain.org/developer-kit/mcp/): bnbchain-mcp server for on-chain tools and IDE integration.
   - [Ask AI](https://docs.bnbchain.org/developer-kit/ask-ai/): Read-only MCP doc search for BNB Chain.
   - [VS Code guide](https://docs.bnbchain.org/developer-kit/ask-ai/vs-code-guide/): Step-by-step Ask AI setup in Visual Studio Code.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -212,7 +212,7 @@
 
 - [Overview](https://docs.bnbchain.org/developer-kit/): Lightweight index of official BNB Chain developer tools.
 - [Greenfield SDK](https://docs.bnbchain.org/developer-kit/greenfield-sdk/): Go and JavaScript client libraries for Greenfield (language tabs).
-- [BNBAgent SDK](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/): Python SDK for on-chain AI agents (ERC-8004, ERC-8183) on BSC.
+- [BNB Agent SDK](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/): Python SDK for on-chain AI agents (ERC-8004, ERC-8183) on BSC.
   - [Quickstart](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/quickstart/): Register agents, run server, use client.
   - [Architecture](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/architecture/): Module system and data flows.
   - [Configuration](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/configuration/): Environment variables.
@@ -220,7 +220,7 @@
   - [Examples](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/examples/): Client, voter, and agent-server flows.
   - [Security](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/security/): Wallet handling and signing policy.
   - [Troubleshooting](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/troubleshooting/): Common errors and fixes.
-- [BNBChain Studio](https://docs.bnbchain.org/developer-kit/bnbchain-studio/): Scaffold and deploy two-layer blockchain seller agents (CLI `bag`, ERC-8004/8183, x402) on BSC.
+- [BNB Agent Studio](https://docs.bnbchain.org/developer-kit/bnbchain-studio/): Scaffold and deploy two-layer blockchain seller agents (CLI `bag`, ERC-8004/8183, x402) on BSC.
   - [Quickstart](https://docs.bnbchain.org/developer-kit/bnbchain-studio/quickstart/): Install, scaffold, run locally, deploy.
   - [Demo](https://docs.bnbchain.org/developer-kit/bnbchain-studio/demo/): End-to-end weather-forecast seller walkthrough.
   - [Architecture](https://docs.bnbchain.org/developer-kit/bnbchain-studio/architecture/): Six-layer stack and two-layer deploy model.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -282,7 +282,7 @@ nav:
           - Feature Lists: ./bnb-greenfield/roadmap/features.md
   - Developer Kit:
       - Overview: ./developer-kit/index.md
-      - BNBAgent SDK:
+      - BNB Agent SDK:
           - Overview: ./developer-kit/bnbagent-sdk/index.md
           - Quickstart: ./developer-kit/bnbagent-sdk/quickstart.md
           - Configuration: ./developer-kit/bnbagent-sdk/configuration.md
@@ -291,7 +291,7 @@ nav:
           - Examples: ./developer-kit/bnbagent-sdk/examples.md
           - Security: ./developer-kit/bnbagent-sdk/security.md
           - Troubleshooting: ./developer-kit/bnbagent-sdk/troubleshooting.md
-      - BNBChain Studio:
+      - BNB Agent Studio:
           - Overview: ./developer-kit/bnbchain-studio/index.md
           - Quickstart: ./developer-kit/bnbchain-studio/quickstart.md
           - Demo: ./developer-kit/bnbchain-studio/demo.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -313,6 +313,8 @@ nav:
           - Architecture: ./developer-kit/mpp-sdk/architecture.md
           - Replay Store: ./developer-kit/mpp-sdk/replay-store.md
           - Examples: ./developer-kit/mpp-sdk/examples.md
+      - Privacy at Scale:
+          - Overview: ./developer-kit/privacy-at-scale/index.md
   - BNB Chain Fusion:
       - BNB Chain Fusion: ./bc-fusion/index.md
       - Overview: ./bc-fusion/overview.md


### PR DESCRIPTION
Add a new Developer Kit page introducing the "Privacy at Scale" institutional privacy stack (ZKP and FHE). Creates docs/developer-kit/privacy-at-scale/index.md and updates docs/developer-kit/index.md, mkdocs.yml, and docs/llms.txt to include the new section and navigation entry. The page covers Intelligent Privacy Pool, ZKredit, BAP-674, and Zama FHE and integrates the topic into the site structure.