### PR TITLE
Add Token Recovery Tool sunset announcements

### DIFF
--- a/docs/announce/index.md
+++ b/docs/announce/index.md
@@ -2,6 +2,26 @@
 # Announcement
 
 <div class="doc-announce">
+    <a href="./token-recovery-sunset-phase3/">
+        <div>
+            <div class="announce-title">Token Recovery Tool: Phase 3 — Self-Service Recovery</div>
+            <div class="announce-desc">Hosted tool discontinued; use the open-source self-service tool from 1 July 2026</div>
+        </div>
+        <span class="announce-date">2026 Jul 1st</span>
+    </a>
+</div>
+
+<div class="doc-announce">
+    <a href="./token-recovery-sunset-plan/">
+        <div>
+            <div class="announce-title">BNB Beacon Chain Token Recovery Tool: Sunset Plan</div>
+            <div class="announce-desc">Three-phase sunset with increasing recovery times</div>
+        </div>
+        <span class="announce-date">2026 Mar 4th</span>
+    </a>
+</div>
+
+<div class="doc-announce">
     <a href="./mendel-bsc/">
         <div>
             <div class="announce-title">Mendel Upgrade of BSC </div>

--- a/docs/announce/token-recovery-sunset-phase2.md
+++ b/docs/announce/token-recovery-sunset-phase2.md
@@ -1,0 +1,33 @@
+# BNB Beacon Chain Token Recovery Tool: Phase 2
+
+<div class="doc-announce-info">
+    <span class="version-tag">Notice</span>
+</div>
+
+Effective **1 May 2026**, the BNB Beacon Chain Token Recovery Tool enters **Phase 2** of its sunset plan.
+
+## What Changes in Phase 2
+
+| | Phase 1 (ended 30 April 2026) | Phase 2 (1 May – 30 June 2026) |
+| --- | --- | --- |
+| **Processing** | Normal operation | Batch-processed |
+| **SLA** | 7 days | 1 month |
+
+Recovery requests submitted during Phase 2 will be processed in batches rather than individually. Expect recovery times of up to **one month**.
+
+## What You Should Do
+
+If you still hold recoverable BEP2 tokens on BNB Beacon Chain, submit your recovery request as soon as possible:
+
+1. Visit the [Token Recovery Tool](https://www.bnbchain.org/en/token-recovery).
+2. Follow the [Token Recovery dApp guide](../bc-fusion/post-fusion/token-recovery.md).
+
+Only BEP2 tokens mirrored to BEP20 tokens on BNB Smart Chain are eligible. Tokens that were never mirrored cannot be recovered.
+
+## What Comes Next — Phase 3
+
+Starting **1 July 2026**, the hosted recovery tool will be discontinued. Users must use the open-source [Token Recover Self-Service Tool](https://github.com/bnb-chain/token-recover-self-service-tools) and sign on-chain transactions manually.
+
+See the [Phase 3 announcement](./token-recovery-sunset-phase3.md) for full details.
+
+For the complete sunset timeline, refer to the [Token Recovery Tool Sunset Plan](./token-recovery-sunset-plan.md).

--- a/docs/announce/token-recovery-sunset-phase3.md
+++ b/docs/announce/token-recovery-sunset-phase3.md
@@ -1,0 +1,222 @@
+# BNB Beacon Chain Token Recovery Tool: Phase 3 — Self-Service Recovery
+
+<div class="doc-announce-info">
+    <span class="version-tag">Notice</span>
+</div>
+
+**Effective Date:** 1 July 2026
+
+**Tool:** [https://github.com/bnb-chain/token-recover-self-service-tools](https://github.com/bnb-chain/token-recover-self-service-tools)
+
+## Important Notice
+
+Effective **1 July 2026**, BNB Chain's hosted [Token Recovery Tool](https://www.bnbchain.org/en/token-recovery) has been **discontinued**. Users who still need to recover BEP2 or BEP8 tokens from the BNB Beacon Chain to BNB Smart Chain (BSC) must now use the self-service tool published at the GitHub repository above.
+
+This guide covers everything you need to complete the recovery successfully.
+
+## What Is This Tool?
+
+The Token Recover Self-Service Tool is an open-source, locally-run web application that lets you recover BEP2 and BEP8 tokens stranded on the BNB Beacon Chain and move them to your BNB Smart Chain (BSC) address — without relying on any third-party custodial service.
+
+Because the tool runs entirely in your browser from your own machine, your private keys and signatures never leave your device.
+
+## What You Will Need Before You Start
+
+Before beginning, make sure you have the following:
+
+- **Node.js** version 24.0.0 or higher installed on your computer.
+- A package manager: npm, yarn, pnpm, or bun.
+- Your **BNB Beacon Chain address** (starts with `bnb1...`) — the address holding the tokens you want to recover.
+- **Trust Wallet** (or another Beacon Chain-compatible wallet) installed as a browser extension, with access to your Beacon Chain account.
+- A **BNB Smart Chain (BSC) wallet address** to receive the recovered tokens.
+- A small amount of **BNB** in that BSC wallet to pay for the on-chain transaction gas fee.
+
+## Setup: Install and Run the Tool Locally
+
+### Step 1 — Clone the repository
+
+Open your terminal and run:
+
+```shell
+git clone https://github.com/bnb-chain/token-recover-self-service-tools.git
+cd token-recover-self-service-tools
+```
+
+### Step 2 — Install dependencies
+
+```shell
+npm install
+```
+
+### Step 3 — (Optional) Configure the API endpoint
+
+By default the tool points to BNB Smart Chain Mainnet. If you want to test on Testnet first, copy the example environment file and edit it:
+
+```shell
+cp .env.example .env.local
+```
+
+Then open `.env.local` and set:
+
+```
+NEXT_PUBLIC_APPROVAL_API=https://testnet-token-recover-api.bnbchain.org
+```
+
+The BSC explorer links in the UI will automatically switch to testnet.bscscan.com when this is set.
+
+### Step 4 — Start the application
+
+```shell
+npm run dev
+```
+
+### Step 5 — Open in your browser
+
+Navigate to: [http://localhost:3000](http://localhost:3000)
+
+You will see a four-step guided recovery flow. Follow the steps below exactly.
+
+## Recovery Walkthrough: The 4 Steps
+
+### Step 1 — Get Recoverable Tokens
+
+Enter your BNB Beacon Chain address (the `bnb1...` address) in the input field and click to fetch.
+
+The tool will display a list of all tokens eligible for recovery on that address. Identify the token you want to recover and note its symbol.
+
+If no tokens appear, your address either has no recoverable balance or has already been processed.
+
+### Step 2 — Generate and Sign the Message (Beacon Chain Wallet)
+
+Fill in the following fields:
+
+- **Token Symbol** — select or enter the token symbol from Step 1
+- **Amount** — enter the amount in human-readable units (e.g. `0.00001000`). The tool automatically converts this to the correct on-chain base units internally.
+- **To BSC Address** — the BNB Smart Chain address where you want the recovered tokens sent. This must be the address whose private key you control, as it will be required to sign the final on-chain transaction in Step 4.
+- **Network** — select Beacon Chain Mainnet (or Testnet if testing)
+
+Click **Generate Sign Message**. The tool will produce a structured JSON message.
+
+Next, click **Sign with Wallet**. Your Trust Wallet (or compatible wallet) browser extension will prompt you to sign the message.
+
+Approve the signing request in your wallet. The tool receives back two values:
+
+- `signature` — a long hex string starting with `0x`
+- `publicKey` — your Beacon Chain public key
+
+!!! warning "Security"
+    Only sign this message in a browser where you trust all installed extensions. Do not sign on shared computers or when multiple wallet extensions are active simultaneously. The tool does not broadcast anything at this stage — no transaction occurs here.
+
+If the signature returned by your wallet does not start with `0x`, add the `0x` prefix manually before proceeding.
+
+### Step 3 — Submit for Approval (Get Merkle Proof)
+
+With the signature and public key from Step 2 in hand, click **Get Approval**.
+
+The tool submits your signed data to the BNB Chain approval server, which validates your ownership and returns:
+
+- `proofs` — a list of Merkle proof hashes
+- `approval_signature` — the server's countersignature authorising the recovery
+
+These values are automatically populated in the tool. You do not need to copy or store them manually — they carry through to Step 4 automatically.
+
+If this step returns an error, double-check that the token symbol and BSC address match exactly what you entered in Step 2. Symbol casing matters.
+
+### Step 4 — Build the Recover Payload and Submit On-Chain (BNB Smart Chain Wallet)
+
+This is the final step. Click **Build Recover Payload**.
+
+The tool assembles a complete payload containing:
+
+- The token symbol (encoded as bytes32)
+- The amount (encoded as a hex integer in base units)
+- Your Beacon Chain owner signature and public key
+- The server's approval signature
+- The full Merkle proof array
+
+!!! important
+    The tool generates this payload locally only. **No transaction is broadcast automatically.**
+
+You must now call the `recover` function on the BNB Smart Chain recovery contract yourself using your BSC wallet (the same address you specified as "To BSC Address" in Step 2).
+
+**Recovery contract address:** `0x0000000000000000000000000000000000003000` ([view on BscScan](https://bscscan.com/address/0x0000000000000000000000000000000000003000))
+
+To submit:
+
+1. Connect your BSC wallet (MetaMask or equivalent) to BNB Smart Chain Mainnet.
+2. Navigate to the contract on BscScan, go to **Write Contract**, and connect your wallet.
+3. Call the `recover` function with the parameters shown in the payload.
+4. Set the gas limit to at least **1,000,000**.
+5. Confirm the transaction in your wallet.
+
+Once the transaction is confirmed on-chain, your tokens will appear in your BSC wallet.
+
+Both the owner signature and the approval signature must start with `0x`. If either is missing the prefix, add it before submitting.
+
+## Two Wallets Are Involved — Key Distinction
+
+| Step | Wallet Used | Purpose | Gas Required? |
+| ---- | ----------- | ------- | ------------- |
+| Step 2 | Beacon Chain wallet (Trust Wallet) | Sign the recovery message | No |
+| Step 4 | BNB Smart Chain wallet (MetaMask etc.) | Broadcast the on-chain recovery transaction | Yes — BNB required |
+
+Make sure both wallets are available before you start. The BSC address you enter in Step 2 must match the wallet you use in Step 4.
+
+## Testnet Practice Run
+
+If you want to test the process before using Mainnet assets:
+
+1. Set `NEXT_PUBLIC_APPROVAL_API=https://testnet-token-recover-api.bnbchain.org` in your `.env.local` file.
+2. Restart the dev server (`npm run dev`).
+3. Use your Beacon Chain Testnet address and a BSC Testnet wallet.
+
+The UI will automatically link to testnet.bscscan.com for transaction verification.
+
+## Troubleshooting
+
+**No tokens shown in Step 1**
+Verify you have entered the correct Beacon Chain address. Ensure the address format begins with `bnb1`. The address is case-sensitive.
+
+**Wallet does not respond in Step 2**
+Ensure Trust Wallet (or your Beacon Chain-compatible wallet) extension is active and unlocked in the same browser. Disable or remove other wallet extensions that may conflict.
+
+**Approval fails in Step 3**
+Check that the token symbol matches exactly (including hyphen and number suffix). Check that your BSC address is a valid `0x`-prefixed EVM address.
+
+**Transaction reverts in Step 4**
+Confirm your gas limit is set to 1,000,000 or higher. Ensure your BSC wallet has sufficient BNB for gas. Confirm both signatures are `0x`-prefixed.
+
+**Signature missing 0x prefix**
+Some wallet implementations omit the `0x` prefix. Prepend `0x` to the signature string before using it in Step 3 or Step 4.
+
+## Security Reminders
+
+- This tool runs entirely in your local browser. Your private key is never transmitted.
+- Always clone the repository directly from [https://github.com/bnb-chain/token-recover-self-service-tools](https://github.com/bnb-chain/token-recover-self-service-tools) — do not use third-party mirrors or modified copies.
+- BNB Chain will never ask you to share your private key or seed phrase to complete a recovery.
+- Report any security vulnerabilities via the repository's Security Policy — do not open a public GitHub issue.
+
+## Quick Reference
+
+| Item | Value |
+| ---- | ----- |
+| Tool repository | [https://github.com/bnb-chain/token-recover-self-service-tools](https://github.com/bnb-chain/token-recover-self-service-tools) |
+| Local app URL | [http://localhost:3000](http://localhost:3000) |
+| Mainnet API | `https://token-recover-api.bnbchain.org` (default) |
+| Testnet API | `https://testnet-token-recover-api.bnbchain.org` |
+| Recovery contract | `0x0000000000000000000000000000000000003000` |
+| Min. Node.js version | 24.0.0 |
+| Recommended gas limit | 1,000,000 |
+
+## Summary: Recovery at a Glance
+
+1. Clone and run the tool locally at [http://localhost:3000](http://localhost:3000)
+2. Enter your Beacon Chain address → view recoverable tokens
+3. Select token, enter amount and BSC destination address → sign message with Beacon Chain wallet
+4. Submit signed data → receive Merkle proof and approval signature from server
+5. Build payload → call the `recover` function on the BSC contract with your BSC wallet
+6. Confirm transaction on-chain → tokens arrive in your BSC wallet
+
+For the latest updates and known issues, refer to the [GitHub repository](https://github.com/bnb-chain/token-recover-self-service-tools).
+
+For the complete sunset timeline, refer to the [Token Recovery Tool Sunset Plan](./token-recovery-sunset-plan.md).

--- a/docs/announce/token-recovery-sunset-plan.md
+++ b/docs/announce/token-recovery-sunset-plan.md
@@ -1,0 +1,41 @@
+# BNB Beacon Chain Token Recovery Tool: Sunset Plan
+
+<div class="doc-announce-info">
+    <span class="version-tag">Notice</span>
+</div>
+
+The official [BNB Beacon Chain Token Recovery Tool](https://www.bnbchain.org/en/token-recovery), which allows asset migration from BNB Beacon Chain to BNB Smart Chain, is entering its sunset phase.
+
+As the tool phases out, BNB Beacon Chain asset holders are urged to act promptly for faster processing times.
+
+For the full announcement, see the [BNB Chain blog post](https://www.bnbchain.org/en/blog/bnb-beacon-chain-token-recovery-tool-sunset-plan).
+
+## Actions for BNB Beacon Chain Asset Holders
+
+BNB Beacon Chain asset holders should migrate their tokens to BNB Smart Chain using the [Token Recovery Tool](https://www.bnbchain.org/en/token-recovery) as soon as possible for faster processing times.
+
+### What Can Be Recovered?
+
+Only BEP2 tokens (on BNB Beacon Chain) that are mirrored to BEP20 tokens (on BNB Smart Chain) are eligible for recovery.
+
+Tokens that were never mirrored are ineligible for recovery. Permissionless mirroring (BEP84) is permanently disabled and will not be re-enabled.
+
+### How to Recover
+
+Visit the [Token Recovery Tool](https://www.bnbchain.org/en/token-recovery) to recover your assets. For step-by-step instructions, refer to the [Token Recovery dApp guide](../bc-fusion/post-fusion/token-recovery.md).
+
+## Sunset Timeline
+
+The sunset will occur in three phases, with recovery times increasing with each phase:
+
+| Phase | Period | Processing |
+| ----- | ------ | ---------- |
+| **Phase 1** | Now till 30 April 2026 | The tool operates normally with recovery requests processed within a **7-day SLA**. |
+| **Phase 2** | 1 May – 30 June 2026 | Recovery requests will be batch-processed with recovery times extended to a **1-month SLA**. |
+| **Phase 3** | 1 July 2026 onwards | Recovery process will be manual and require user transaction signing. The hosted tool will be discontinued. See the [Phase 3 self-service announcement](./token-recovery-sunset-phase3.md). |
+
+## Act Now
+
+To avoid delays and complications, BNB Beacon Chain asset holders are encouraged to take action as soon as possible before the recovery tool phases out.
+
+Start migrating using the [Token Recovery Tool](https://www.bnbchain.org/en/token-recovery).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,8 +62,10 @@ nav:
   - Announcements:
     - Announcements: ./announce/index.md
     - Upcoming:
-      - NA: ./announce/na.md
+      - Token Recovery Tool Sunset — Phase 3 (Self-Service): ./announce/token-recovery-sunset-phase3.md
     - Passed:
+      - Token Recovery Tool Sunset — Phase 2: ./announce/token-recovery-sunset-phase2.md
+      - Token Recovery Tool Sunset Plan: ./announce/token-recovery-sunset-plan.md
       - Fjord Hardfork(opBNB): ./announce/fjord-opbnb.md
       - Wright Hardfork(opBNB): ./announce/wright-opbnb.md
       - Mongolian Hardfork(Greenfield): ./announce/mongolian-greenfield.md


### PR DESCRIPTION
Introduce three announcement pages for the Token Recovery Tool sunset: Phase 2 (batch processing, 1 May–30 Jun 2026), Phase 3 (self-service, effective 1 Jul 2026) and a Sunset Plan overview. Update docs/announce/index.md to surface the new notices and update mkdocs.yml navigation to include the new pages. Phase 3 doc includes detailed self-service recovery instructions and setup steps for the open-source tool.