### PR TITLE
Add NodeFlare to BSC RPC providers

### DIFF
--- a/docs/bnb-smart-chain/developers/json_rpc/json-rpc-endpoint.md
+++ b/docs/bnb-smart-chain/developers/json_rpc/json-rpc-endpoint.md
@@ -64,6 +64,8 @@ You could find more endpoints from **[here](https://chainlist.org/chain/56)**.
 
 * **Alchemy:** <https://docs.alchemy.com/reference/api-overview>
 
+* **NodeFlare:** <https://nodeflare.app/chains/bnb>
+
 ### Starting HTTP JSON-RPC
 
 You can start the HTTP JSON-RPC with the --http flag


### PR DESCRIPTION
Adds NodeFlare to the RPC Providers list, same format as existing entries.

NodeFlare serves BNB Smart Chain (56) from multi-region dedicated nodes (Asia/EU/UK/US) with a free public endpoint (no API key) and a free keyed tier including `eth_getLogs` and debug/trace methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)