### PR TITLE
docs: propose adding Garden as a route provider

### DIFF
--- a/docs/bnb-smart-chain/cross-chain-bridge.md
+++ b/docs/bnb-smart-chain/cross-chain-bridge.md
@@ -24,6 +24,7 @@ Many users don’t realize that cross-chain transfers are possible or easy. BNB 
 * Meson
 * LayerZero
 * Mayan
+* Garden Finance 
 
 > ✅ We help users **see available routes** for transferring assets **into or out of BNB Chain**, but we **do not operate the routes or control token availability**.
 


### PR DESCRIPTION
Requesting Garden be considered as a supported route provider for the BNB Chain bridge aggregator.

Garden enables native Bitcoin to BNB Chain transfers. None of the six current providers route native BTC, so this fills a gap rather than duplicating an existing route.

Settlement uses HTLC-based atomic swaps, so swaps are non-custodial and have no wrapped intermediate asset.