### PR TITLE
Add ERC-8056 Scaled UI Amount docs

### DIFF
--- a/docs/developer-kit/index.md
+++ b/docs/developer-kit/index.md
@@ -13,4 +13,5 @@ Index of official BNB Chain tools. Full SDK guides live in each product folder b
 | **Greenfield SDK** | Greenfield | [greenfield-sdk/](greenfield-sdk/index.md) |
 | **MCP & Ask AI** | BSC, opBNB, Greenfield (bnbchain-mcp); BSC docs (Ask AI) | [mcp/](mcp/index.md) |
 | **MPP SDK** | BSC, opBNB | [mpp-sdk/](mpp-sdk/index.md) |
+| **Scaled UI Amount (ERC-8056)** | BSC | [scaled-ui-amount/](scaled-ui-amount/index.md) |
 | **Privacy at Scale** | BSC | [privacy-at-scale/](privacy-at-scale/index.md) |

--- a/docs/developer-kit/scaled-ui-amount/demo.md
+++ b/docs/developer-kit/scaled-ui-amount/demo.md
@@ -1,0 +1,133 @@
+---
+title: Scaled UI Amount Demo
+---
+
+# Demo — UI multiplier in four steps
+
+This walkthrough covers what almost every app needs for ERC-8056 tokens: detect the standard, show the correct balance, convert user input for a transfer, and react when the multiplier changes.
+
+Uses **ethers v6** against any BSC JSON-RPC endpoint. Set `tokenContract` and `holder` to your target ERC-8056 contract and account.
+
+## Prerequisites
+
+```bash
+npm install ethers
+```
+
+```javascript
+import { ethers } from "ethers";
+
+const provider = new ethers.JsonRpcProvider("<your-bsc-rpc-url>");
+const tokenContract = "<erc-8056-contract>"; // from your allowlist or config
+const holder = "<holder-account>";
+```
+
+## 1. Detect ERC-8056
+
+```javascript
+const IScaledUIAmountABI = [
+  "function uiMultiplier() view returns (uint256)",
+  "function balanceOfUI(address) view returns (uint256)",
+  "function toUIAmount(uint256) view returns (uint256)",
+  "function fromUIAmount(uint256) view returns (uint256)",
+  "function balanceOf(address) view returns (uint256)",
+  "function decimals() view returns (uint8)",
+  "function supportsInterface(bytes4) view returns (bool)",
+  "event UIMultiplierUpdated(uint256,uint256,uint256,uint256)",
+];
+
+const token = new ethers.Contract(tokenContract, IScaledUIAmountABI, provider);
+
+// Interface ID is defined in EIP-8056 — load from your config or standard constants
+const erc8056InterfaceId = "<eip-8056-interface-id>";
+const isScaledUIAmount = await token.supportsInterface(erc8056InterfaceId);
+
+if (!isScaledUIAmount) {
+  throw new Error("Contract does not implement ERC-8056");
+}
+```
+
+!!! tip "Production detection"
+    Many integrators maintain a curated allowlist of compliant contracts and fall back to `supportsInterface()` for unknown tokens. See [EIP-8056](https://eips.ethereum.org/EIPS/eip-8056) for the canonical interface ID.
+
+## 2. Show the correct balance
+
+Use `balanceOfUI()` — not `balanceOf()` — for display.
+
+```javascript
+const decimals = await token.decimals();
+const uiBalanceRaw = await token.balanceOfUI(holder);
+const uiBalance = Number(uiBalanceRaw) / 10 ** Number(decimals);
+
+const rawBalance = await token.balanceOf(holder);
+const multiplier = Number(await token.uiMultiplier()) / 1e18;
+
+console.log(`UI balance:   ${uiBalance} shares`);
+console.log(`Raw balance:  ${Number(rawBalance) / 10 ** Number(decimals)} units`);
+console.log(`Multiplier:   ${multiplier}x`);
+```
+
+With a `2.0x` multiplier, a holder with `100` raw units sees `200` shares — total economic value unchanged.
+
+## 3. Convert a send amount
+
+Users think in UI amounts (shares). Convert back to raw before calling `transfer()`.
+
+```javascript
+const sharesToSend = "200"; // user enters 200 shares
+const uiAmountScaled = ethers.parseUnits(sharesToSend, decimals);
+const rawAmount = await token.fromUIAmount(uiAmountScaled); // e.g. 100_000_000 raw (if multiplier = 2.0x)
+
+console.log(`Sending ${sharesToSend} shares → ${rawAmount} raw units on-chain`);
+// await token.connect(signer).transfer(recipient, rawAmount);
+```
+
+On the confirmation screen, show the UI amount the user entered — not the raw value.
+
+## 4. React to multiplier changes
+
+Listen for `UIMultiplierUpdated`. If `effectiveAtTimestamp` is in the future, the change is scheduled — keep using the old multiplier until it activates.
+
+```javascript
+token.on(
+  "UIMultiplierUpdated",
+  (oldMultiplier, newMultiplier, setAtTimestamp, effectiveAtTimestamp) => {
+    const oldMult = Number(oldMultiplier) / 1e18;
+    const newMult = Number(newMultiplier) / 1e18;
+    const nowSec = Math.floor(Date.now() / 1000);
+
+    console.log(`Multiplier change announced at ${setAtTimestamp}`);
+    console.log(`Old: ${oldMult}x → New: ${newMult}x`);
+    console.log(`Takes effect at: ${effectiveAtTimestamp}`);
+
+    if (Number(effectiveAtTimestamp) > nowSec) {
+      // Scheduled — old multiplier still active; show a notice to users
+      console.log("Corporate action scheduled — balances will adjust at effective time.");
+    } else {
+      // Immediate — refresh cached multiplier and re-fetch balances
+      refreshBalances(tokenContract);
+    }
+  }
+);
+
+async function refreshBalances(contract) {
+  const t = new ethers.Contract(contract, IScaledUIAmountABI, provider);
+  const multiplier = Number(await t.uiMultiplier()) / 1e18;
+  console.log(`Current UI multiplier: ${multiplier}x`);
+}
+```
+
+## Common pitfalls
+
+| Pitfall | Fix |
+|---------|-----|
+| Showing `balanceOf()` as the primary balance | Use `balanceOfUI()` or `toUIAmount(balanceOf())` |
+| Passing UI amounts to `transfer()` | Always `fromUIAmount()` first — ERC-20 functions use raw amounts |
+| Applying a new multiplier before `effectiveAtTimestamp` | Old multiplier stays active until the effective time |
+| Manual `raw × multiplier / 1e18` math | Prefer `toUIAmount()` / `fromUIAmount()` to match contract rounding |
+
+## Next steps
+
+For per-audience integration (wallets, explorers, DEX RFQ, lending/collateral) and guidance on splits vs. dividends, see the [ERC-8056 overview](index.md) or contact the token issuer for the full Partner Integration Guide.
+
+[← Scaled UI Amount overview](index.md) · [Developer Kit overview](../index.md)

--- a/docs/developer-kit/scaled-ui-amount/index.md
+++ b/docs/developer-kit/scaled-ui-amount/index.md
@@ -1,0 +1,97 @@
+---
+title: Scaled UI Amount (ERC-8056)
+---
+
+# Scaled UI Amount (ERC-8056)
+
+Some ERC-20 tokens on BNB Smart Chain implement **ERC-8056 (Scaled UI Amount)**. The standard adds an on-chain **UI multiplier** that converts raw token balances into the share count users should see, so corporate actions like stock splits, reverse splits, and dividends can be reflected **without minting, burning, or migrating tokens**.
+
+If your app displays `balanceOf()` directly, users will see wrong balances and prices whenever the multiplier changes.
+
+## What is the UI multiplier?
+
+The UI multiplier is a single scalar stored on the token contract. It translates raw on-chain amounts into UI display amounts.
+
+**Example — 2-for-1 stock split**
+
+| | Before split | After split |
+|---|-------------|-------------|
+| Raw on-chain balance | 100 tokens | 100 tokens (unchanged) |
+| UI multiplier | `1.0` (`1e18`) | `2.0` (`2e18`) |
+| UI display amount | 100 shares | 200 shares |
+| UI price per share | $50.00 | $25.00 |
+| Total value | $5,000 | $5,000 |
+
+No tokens move. Only the multiplier changes — and every balance, transfer amount, and price you show should scale with it.
+
+## Core formulas
+
+The multiplier is always **18-decimal fixed point** (`1e18` = 1.0). Apply it after standard ERC-20 decimal adjustment.
+
+| Term | Definition |
+|------|------------|
+| **Raw amount** | What `balanceOf()` returns (`uint256`) |
+| **UI multiplier** | Returned by `uiMultiplier()` — `1e18` = 1.0, `2e18` = 2.0 |
+| **UI amount** | What users should see — `rawAmount × uiMultiplier / 1e18` |
+| **UI price** | Price per share. CEX Spot already quotes UI price; convert raw-denominated feeds with `rawPrice × 1e18 / uiMultiplier` |
+
+```
+UI amount = rawAmount × uiMultiplier / 1e18
+UI price  = rawPrice × 1e18 / uiMultiplier   ← only for raw-denominated price sources
+```
+
+Prefer the on-chain helpers `toUIAmount()` and `fromUIAmount()` over manual arithmetic — they match contract rounding.
+
+## Contract interface
+
+```solidity
+interface IScaledUIAmount {
+    event UIMultiplierUpdated(
+        uint256 oldMultiplier,
+        uint256 newMultiplier,
+        uint256 setAtTimestamp,
+        uint256 effectiveAtTimestamp
+    );
+
+    function uiMultiplier() external view returns (uint256);
+    function toUIAmount(uint256 rawAmount) external view returns (uint256);
+    function fromUIAmount(uint256 uiAmount) external view returns (uint256);
+    function balanceOfUI(address account) external view returns (uint256);
+    function setUIMultiplier(uint256 newMultiplier, uint256 effectiveAtTimestamp) external;
+}
+```
+
+| Function | Use it for |
+|----------|------------|
+| `balanceOfUI(address)` | Primary balance display |
+| `toUIAmount(rawAmount)` | Transfer history, supply, any raw → UI conversion |
+| `fromUIAmount(uiAmount)` | User input → `transfer()` / `approve()` params |
+| `uiMultiplier()` | Price conversion, multiplier badges, caching |
+
+Detect ERC-8056 tokens with ERC-165 `supportsInterface()` using the interface ID from [EIP-8056](https://eips.ethereum.org/EIPS/eip-8056), or maintain a curated allowlist of known compliant contracts.
+
+## Scheduled multiplier changes
+
+Issuers can announce a future multiplier via `setUIMultiplier(newMultiplier, effectiveAtTimestamp)`. The `UIMultiplierUpdated` event fires immediately, but all view functions keep using the **old** multiplier until `block.timestamp >= effectiveAtTimestamp`.
+
+When a future `effectiveAtTimestamp` is detected, show a notice to users and refresh cached values once the effective time passes. Do not apply the new multiplier early.
+
+## Integration checklist
+
+| Surface | Display to user | On-chain |
+|---------|-----------------|----------|
+| Balance | `balanceOfUI(address)` | `balanceOf(address)` |
+| Send amount | User enters UI amount | `fromUIAmount()` → `transfer()` |
+| Transfer history | `toUIAmount(rawTransferAmount)` | Raw `Transfer` event amount |
+| Price | CEX Spot price (already UI) or convert raw feeds | — |
+| Total supply | `toUIAmount(totalSupply())` | `totalSupply()` |
+
+---
+
+## Documentation
+
+| Guide | Description |
+|-------|-------------|
+| [Demo](demo.md) | Detect ERC-8056, show the correct balance, convert a send amount, and react to multiplier changes |
+
+[← Developer Kit overview](../index.md)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -234,6 +234,8 @@
   - [Architecture](https://docs.bnbchain.org/developer-kit/mpp-sdk/architecture/): Wire schema and verifiers.
   - [Replay store](https://docs.bnbchain.org/developer-kit/mpp-sdk/replay-store/): Durable atomic replay protection.
   - [Examples](https://docs.bnbchain.org/developer-kit/mpp-sdk/examples/): charge-server, charge-demo, bnb-wire-demo.
+- [Scaled UI Amount (ERC-8056)](https://docs.bnbchain.org/developer-kit/scaled-ui-amount/): UI multiplier for ERC-8056 tokens — balances, transfers, and prices without mint/burn.
+  - [Demo](https://docs.bnbchain.org/developer-kit/scaled-ui-amount/demo/): Detect ERC-8056, display balances, convert send amounts, handle multiplier changes.
 - [Privacy at Scale](https://docs.bnbchain.org/developer-kit/privacy-at-scale/): ZKP and FHE institutional privacy stack — Intelligent Privacy Pool, ZKredit, and Zama FHE.
   - [Overview](https://docs.bnbchain.org/developer-kit/mcp/): bnbchain-mcp server for on-chain tools and IDE integration.
   - [Ask AI](https://docs.bnbchain.org/developer-kit/ask-ai/): Read-only MCP doc search for BNB Chain.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -315,6 +315,9 @@ nav:
           - Architecture: ./developer-kit/mpp-sdk/architecture.md
           - Replay Store: ./developer-kit/mpp-sdk/replay-store.md
           - Examples: ./developer-kit/mpp-sdk/examples.md
+      - Scaled UI Amount (ERC-8056):
+          - Overview: ./developer-kit/scaled-ui-amount/index.md
+          - Demo: ./developer-kit/scaled-ui-amount/demo.md
       - Privacy at Scale:
           - Overview: ./developer-kit/privacy-at-scale/index.md
   - BNB Chain Fusion:


### PR DESCRIPTION
Introduce documentation for Scaled UI Amount (ERC-8056): add overview and demo pages with guidance and example ethers v6 snippets for detecting the standard, displaying UI balances, converting send amounts, and handling multiplier updates. Update developer kit index and mkdocs navigation to surface the new pages, and add references to docs/llms.txt. Files added: docs/developer-kit/scaled-ui-amount/index.md, docs/developer-kit/scaled-ui-amount/demo.md; files updated: docs/developer-kit/index.md, docs/llms.txt, mkdocs.yml.