### PR TITLE
docs: add OpenChainBench RPC benchmark reference for BNB and opBNB

### DIFF
--- a/docs/bnb-opbnb/get-started/network-info.md
+++ b/docs/bnb-opbnb/get-started/network-info.md
@@ -38,3 +38,6 @@ NodeReal supports the opBNB network, you can create your free opBNB RPC endpoint
 *To use the above private RPC endpoint, make sure to login to [MegaNode service](https://nodereal.io/meganode) and create your private endpoints.*
 
 
+## Benchmark
+
+See the [OpenChainBench opBNB RPC benchmark](https://openchainbench.com/benchmarks/opbnb-rpc) for independent p50/p90/p99 latency and success rate across community providers.

--- a/docs/bnb-smart-chain/developers/json_rpc/json-rpc-endpoint.md
+++ b/docs/bnb-smart-chain/developers/json_rpc/json-rpc-endpoint.md
@@ -64,6 +64,10 @@ You could find more endpoints from **[here](https://chainlist.org/chain/56)**.
 
 * **Blockmachine:** <https://blockmachine.io/bnb-chain-rpc>
 
+### Benchmark
+
+See the [OpenChainBench BNB RPC benchmark](https://openchainbench.com/benchmarks/bnb-rpc) for independent p50/p90/p99 latency and success rate across community providers.
+
 ### Starting HTTP JSON-RPC
 
 You can start the HTTP JSON-RPC with the --http flag


### PR DESCRIPTION
## Summary

Adds a short "Benchmark" section to two RPC endpoint pages, linking to the [OpenChainBench](https://openchainbench.com) independent latency benchmarks for BNB Smart Chain and opBNB. The benchmark probes a set of community providers every 60 seconds from three regions (US East, EU West, Singapore), publishing p50/p90/p99 latency and success rate under CC BY 4.0.

## Changes
- `docs/bnb-smart-chain/developers/json_rpc/json-rpc-endpoint.md` — added `### Benchmark` section after the RPC Providers list
- `docs/bnb-opbnb/get-started/network-info.md` — added `## Benchmark` section at end of file