### PR TITLE
docs: remove SubQuery RPC endpoint references

### DIFF
--- a/docs/bnb-smart-chain/developers/json_rpc/json-rpc-endpoint.md
+++ b/docs/bnb-smart-chain/developers/json_rpc/json-rpc-endpoint.md
@@ -26,7 +26,6 @@ If you need to pull logs frequently, we recommend using WebSockets to push new l
 * https://bsc-dataseed.ninicoin.io
 * https://bsc.nodereal.io
 * https://bsc-dataseed-public.bnbchain.org
-* https://bnb.rpc.subquery.network/public
 
 You could find more endpoints from **[here](https://chainlist.org/chain/56)**.
 
@@ -57,8 +56,6 @@ You could find more endpoints from **[here](https://chainlist.org/chain/56)**.
 * **NOWNodes:** <https://nownodes.io/nodes/bsc>
   
 * **dRPC:** <https://drpc.org/chainlist/bsc>
-
-* **SubQuery:** <https://rpc.subquery.network/56)>
 
 * **All That Node:** <https://www.allthatnode.com/bsc.dsrv>
 

--- a/docs/llms-full-bnb-smart-chain.txt
+++ b/docs/llms-full-bnb-smart-chain.txt
@@ -243,7 +243,6 @@ If you need to pull logs frequently, we recommend using WebSockets to push new l
 * https://bsc-dataseed.ninicoin.io
 * https://bsc.nodereal.io
 * https://bsc-dataseed-public.bnbchain.org
-* https://bnb.rpc.subquery.network/public
 
 You could find more endpoints from **[here](https://chainlist.org/chain/56)**.
 
@@ -274,8 +273,6 @@ You could find more endpoints from **[here](https://chainlist.org/chain/56)**.
 * **NOWNodes:** <https://nownodes.io/nodes/bsc>
   
 * **dRPC:** <https://drpc.org/chainlist/bsc>
-
-* **SubQuery:** <https://rpc.subquery.network/56>
 
 * **All That Node:** <https://www.allthatnode.com/bsc.dsrv>
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1015,7 +1015,6 @@ If you need to pull logs frequently, we recommend using WebSockets to push new l
 * https://bsc-dataseed.ninicoin.io
 * https://bsc.nodereal.io
 * https://bsc-dataseed-public.bnbchain.org
-* https://bnb.rpc.subquery.network/public
 
 You could find more endpoints from **[here](https://chainlist.org/chain/56)**.
 
@@ -1046,8 +1045,6 @@ You could find more endpoints from **[here](https://chainlist.org/chain/56)**.
 * **NOWNodes:** <https://nownodes.io/nodes/bsc>
   
 * **dRPC:** <https://drpc.org/chainlist/bsc>
-
-* **SubQuery:** <https://rpc.subquery.network/56)>
 
 * **All That Node:** <https://www.allthatnode.com/bsc.dsrv>
 


### PR DESCRIPTION
## Summary
- Remove `subquery.network` mainnet RPC endpoint and SubQuery provider listing from the BSC JSON-RPC endpoint page
- Mirror the same removals in `docs/llms-full.txt` and `docs/llms-full-bnb-smart-chain.txt`

## Test plan
- [ ] Confirm `git grep -i subquery` returns no matches in docs
- [ ] Spot-check JSON-RPC endpoint page renders without SubQuery entries
- [ ] Confirm MkDocs build CI passes