### PR TITLE
docs: switch BNB Agent Studio CLI install to npm

### DIFF
--- a/docs/developer-kit/bnbchain-studio/demo.md
+++ b/docs/developer-kit/bnbchain-studio/demo.md
@@ -19,7 +19,7 @@ Commands and behavior match the [bnbagent-studio](https://github.com/bnb-chain/b
 
 ## 1. Installation
 
-Open the [bnbagent-studio](https://github.com/bnb-chain/bnbagent-studio) repo in your AI IDE and ask it to install the workspace packages. For a one-line production install instead, use `pip install bnbagent-studio` — see [Quickstart](quickstart.md).
+Open the [bnbagent-studio](https://github.com/bnb-chain/bnbagent-studio) repo in your AI IDE and ask it to install the workspace packages. For a one-line production install instead, use `npm install -g @bnbagent/studio-cli` — see [Quickstart](quickstart.md).
 
 ```text
 Now working from /Users/username/Desktop/project-directory. What would you like to do?

--- a/docs/developer-kit/bnbchain-studio/index.md
+++ b/docs/developer-kit/bnbchain-studio/index.md
@@ -16,7 +16,7 @@ A seller agent earns on-chain by offering services over **ERC-8004** (identity) 
 
 | Artifact | Package | Purpose |
 |----------|---------|---------|
-| **`bag` CLI** | `bnbagent-studio` | Scaffold projects, manage wallets, run locally, deploy |
+| **`bag` CLI** | `@bnbagent/studio-cli` | Scaffold projects, manage wallets, run locally, deploy |
 | **Runtime library** | `bnbagent-studio-core` | Wallet, ERC-8004/8183, x402, signing policy — imported by emitted agent code |
 | **MCP server** | `bnbagent-studio` | 15 read-only chain tools for your IDE |
 | **Skills** | bundled in CLI | 10 procedure playbooks for Claude Code / Cursor |
@@ -24,10 +24,8 @@ A seller agent earns on-chain by offering services over **ERC-8004** (identity) 
 Install one command:
 
 ```bash
-pip install bnbagent-studio
+npm install -g @bnbagent/studio-cli
 ```
-
-`pip` auto-pulls `bnbagent-studio-core`. The CLI is also available via `uv tool install bnbagent-studio`.
 
 ## Two-layer deploy model
 
@@ -92,9 +90,9 @@ Optional: testnet funds (only for paid LLM models or on-chain settle — default
 ## Package
 
 ```bash
-pip install bnbagent-studio
+npm install -g @bnbagent/studio-cli
 ```
 
-[PyPI — bnbagent-studio](https://pypi.org/project/bnbagent-studio/) · [PyPI — bnbagent-studio-core](https://pypi.org/project/bnbagent-studio-core/)
+[npm — @bnbagent/studio-cli](https://www.npmjs.com/package/@bnbagent/studio-cli) · [PyPI — bnbagent-studio-core](https://pypi.org/project/bnbagent-studio-core/)
 
 [← Developer Kit overview](../index.md)

--- a/docs/developer-kit/bnbchain-studio/quickstart.md
+++ b/docs/developer-kit/bnbchain-studio/quickstart.md
@@ -9,11 +9,9 @@ End-to-end path from zero to a running two-layer seller on BSC testnet. Steps 1�
 ## 1. Install the CLI
 
 ```bash
-pip install bnbagent-studio
-bag --version        # → bag 0.0.1
+npm install -g @bnbagent/studio-cli
+bag --version
 ```
-
-Alternative: `uv tool install bnbagent-studio` for an isolated machine-wide CLI.
 
 **Prerequisite — AgentCore CLI:**
 


### PR DESCRIPTION
## Summary
- Replace `pip install bnbagent-studio` / `uv tool install bnbagent-studio` with `npm install -g @bnbagent/studio-cli` for the `bag` CLI
- Update the Studio overview package table and package links to match (`@bnbagent/studio-cli` on npm)

## Test plan
- [x] Confirm Quickstart / Overview / Demo install snippets show the npm command
- [x] Confirm no remaining `pip install bnbagent-studio` CLI install instructions
- [ ] Confirm MkDocs build CI passes