### PR TITLE
feat: Add OnFinality as RPC provider

### DIFF
--- a/docs/bnb-smart-chain/developers/json_rpc/json-rpc-endpoint.md
+++ b/docs/bnb-smart-chain/developers/json_rpc/json-rpc-endpoint.md
@@ -26,6 +26,7 @@ If you need to pull logs frequently, we recommend using WebSockets to push new l
 * https://bsc-dataseed.ninicoin.io
 * https://bsc.nodereal.io
 * https://bsc-dataseed-public.bnbchain.org
+* https://bnb.api.onfinality.io/public
 
 You could find more endpoints from **[here](https://chainlist.org/chain/56)**.
 
@@ -56,6 +57,8 @@ You could find more endpoints from **[here](https://chainlist.org/chain/56)**.
 * **NOWNodes:** <https://nownodes.io/nodes/bsc>
   
 * **dRPC:** <https://drpc.org/chainlist/bsc>
+
+* **OnFinality:** <https://onfinality.io/en/networks/bnb>
 
 * **All That Node:** <https://www.allthatnode.com/bsc.dsrv>
 

--- a/docs/llms-full-bnb-smart-chain.txt
+++ b/docs/llms-full-bnb-smart-chain.txt
@@ -243,6 +243,7 @@ If you need to pull logs frequently, we recommend using WebSockets to push new l
 * https://bsc-dataseed.ninicoin.io
 * https://bsc.nodereal.io
 * https://bsc-dataseed-public.bnbchain.org
+* https://bnb.api.onfinality.io/public
 
 You could find more endpoints from **[here](https://chainlist.org/chain/56)**.
 
@@ -273,6 +274,8 @@ You could find more endpoints from **[here](https://chainlist.org/chain/56)**.
 * **NOWNodes:** <https://nownodes.io/nodes/bsc>
   
 * **dRPC:** <https://drpc.org/chainlist/bsc>
+
+* **OnFinality:** <https://onfinality.io/en/networks/bnb>
 
 * **All That Node:** <https://www.allthatnode.com/bsc.dsrv>
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1015,6 +1015,7 @@ If you need to pull logs frequently, we recommend using WebSockets to push new l
 * https://bsc-dataseed.ninicoin.io
 * https://bsc.nodereal.io
 * https://bsc-dataseed-public.bnbchain.org
+* https://bnb.api.onfinality.io/public
 
 You could find more endpoints from **[here](https://chainlist.org/chain/56)**.
 
@@ -1045,6 +1046,8 @@ You could find more endpoints from **[here](https://chainlist.org/chain/56)**.
 * **NOWNodes:** <https://nownodes.io/nodes/bsc>
   
 * **dRPC:** <https://drpc.org/chainlist/bsc>
+
+* **OnFinality:** <https://onfinality.io/en/networks/bnb>
 
 * **All That Node:** <https://www.allthatnode.com/bsc.dsrv>
 


### PR DESCRIPTION
OnFinality provides public BNB Smart Chain RPC infrastructure and can be used as an additional endpoint option for developers and applications interacting with BNB Chain.

### Changes

* Added OnFinality to the BNB Smart Chain RPC provider list
* Added the public BNB Smart Chain RPC endpoint
* Followed the existing provider format used in this repository

The endpoint has been tested and is publicly accessible.
