### PR TITLE
docs: clarify Studio demo x402 requires auto-topup (fix #878)

### DIFF
--- a/docs/developer-kit/bnbchain-studio/demo.md
+++ b/docs/developer-kit/bnbchain-studio/demo.md
@@ -98,7 +98,7 @@ What bag init gives you out of the box
 | Protocol                     | Included       | Notes                                                                                          |
 |------------------------------|----------------|------------------------------------------------------------------------------------------------|
 | ERC-8183 (earn from jobs)    | ✅ auto        | Full buy/quote/fulfill/settle flow in studio.toml                                              |
-| x402 (pay for APIs)          | ✅ auto        | Only when --llm-provider pieverse-llm                                                          |
+| x402 (pay for APIs)          | ✅ auto        | Only when --llm-provider pieverse-llm and auto-topup is enabled                                |
 | ERC-8004 (on-chain identity) | ⚡ post-init   | Config is in chain_tools; register with bag erc8004 register after deploy                      |
 | Chain read tools             | ✅ auto        | 15 read-only tools: agent_info, job_status, token_balance, etc. all in chain_tools.py          |
 
@@ -114,7 +114,7 @@ $ cd ~/Desktop && uv run bag init weather-seller \
     --storage-provider local \
     --no-auto-topup
 
-- pieverse-llm — gets you x402 buyer + [payments.x402] section automatically
+- pieverse-llm — gets you x402 buyer + [payments.x402] section (only when auto-topup is enabled)
 - bsc-testnet — safe defaults for the weather-seller walkthrough
 - local storage — skip Pinata for now; upgrade to pinata before public launch
 - --no-auto-topup — you control when wallet is funded


### PR DESCRIPTION
## Summary
- Restores the intentional docs fix from [#878](https://github.com/bnb-chain/bnb-chain.github.io/pull/878) for `bnbagent-studio#51`: x402 buyer config is emitted only when `--llm-provider pieverse-llm` **and** auto-topup is enabled.
- Keeps the `title: BNB Agent Studio Demo` front matter that #878 incorrectly removed.
- Avoids the broken `llms-full.txt` rewrite that made #878 unmergeable against `main`.

## Why a replacement PR
Upstream write access is unavailable on the bot branch `ai-docs/bnb-chain-bnbagent-studio-51-f92f5f62`, so this lands the same content fix cleanly from current `main`.

Lifecycle-ID: 0cb8100d-d96f-41c5-a921-5770b6223917

## Test plan
- [ ] Confirm `docs/developer-kit/bnbchain-studio/demo.md` still has YAML `title: BNB Agent Studio Demo`
- [ ] Confirm the protocol table and init bullets mention auto-topup for x402
- [ ] Confirm no unrelated `docs/llms-full.txt` changes
- [ ] Close #878 after this merges (or after review prefers this PR)