### PR TITLE
docs: keep Studio llms index updates without stripping titles (fix #879)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -557,3 +557,16 @@ Bsc implement EIP-4844, which support Shard Blob Transactions, as described in  
 ### Other BSC API
 
 Bsc implement some others apis, as described in: [BSC API](bsc-api-list.md#others).
+
+## BNB Agent Studio
+> Source: https://docs.bnbchain.org/developer-kit/bnbchain-studio/
+
+Scaffold, run, and deploy a **two-layer blockchain seller** on BNB Chain. BNB Agent Studio (`bnbagent-studio`) lets you describe what you want in Claude Code or Cursor; the studio emits a working agent project that **you own**, then helps you develop, debug, and deploy it.
+## Quickstart
+> Source: https://docs.bnbchain.org/developer-kit/bnbchain-studio/quickstart/
+
+End-to-end path from zero to a running two-layer seller on BSC testnet. Steps 1–2 are one-time machine setup; step 3 is where you spend most of your time — talking to your AI tool, which drives `bag` for you.
+## Demo
+> Source: https://docs.bnbchain.org/developer-kit/bnbchain-studio/demo/
+
+This walkthrough follows the full BNB Agent Studio path for a single example: a **weather-forecast seller** on BSC testnet. You install the CLI, scaffold the agent with your AI IDE, set up a wallet, fund it, activate an LLM, run locally, negotiate a sale, register on-chain, and deploy.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -220,8 +220,8 @@
   - [Examples](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/examples/): Client, voter, and agent-server flows.
   - [Security](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/security/): Wallet handling and signing policy.
   - [Troubleshooting](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/troubleshooting/): Common errors and fixes.
-- [BNB Agent Studio](https://docs.bnbchain.org/developer-kit/bnbchain-studio/): Scaffold and deploy two-layer blockchain seller agents (CLI `bag`, ERC-8004/8183, x402) on BSC.
-  - [Quickstart](https://docs.bnbchain.org/developer-kit/bnbchain-studio/quickstart/): Install, scaffold, run locally, deploy.
+- [BNB Agent Studio](https://docs.bnbchain.org/developer-kit/bnbchain-studio/): Scaffold, run, and deploy two-layer blockchain seller agents (CLI `bag`, ERC-8004/8183, x402) on BNB Chain.
+  - [Quickstart](https://docs.bnbchain.org/developer-kit/bnbchain-studio/quickstart/): End-to-end path from zero to a running two-layer seller on BSC testnet.
   - [Demo](https://docs.bnbchain.org/developer-kit/bnbchain-studio/demo/): End-to-end weather-forecast seller walkthrough.
   - [Architecture](https://docs.bnbchain.org/developer-kit/bnbchain-studio/architecture/): Six-layer stack and two-layer deploy model.
   - [Configuration](https://docs.bnbchain.org/developer-kit/bnbchain-studio/configuration/): studio.toml, .env.local, cross-layer sync.


### PR DESCRIPTION
## Summary
- Keeps the useful `docs/llms.txt` and `docs/llms-full.txt` Studio index updates from [#879](https://github.com/bnb-chain/bnb-chain.github.io/pull/879).
- Drops the incorrect removal of YAML `title` front matter from `demo.md`, `index.md`, and `quickstart.md`.

## Why a replacement PR
[#879](https://github.com/bnb-chain/bnb-chain.github.io/pull/879) mixed a valid llms sync with harmful title deletions. Upstream bot branch is not writable from this account, so this lands the good half cleanly from current `main`.

Lifecycle-ID: 55fd531e-07a2-4739-b0f0-eb55865edbd4

## Test plan
- [ ] Confirm no changes under `docs/developer-kit/bnbchain-studio/*.md`
- [ ] Confirm Studio / Quickstart / Demo stubs appended in `docs/llms-full.txt`
- [ ] Confirm Studio + Quickstart blurbs updated in `docs/llms.txt`
- [ ] Close #879 after this merges