### PR TITLE
docs(bnbagent-sdk): fix non-existent server module, install extras, and 404 example links

### DIFF
--- a/docs/developer-kit/bnbagent-sdk/architecture.md
+++ b/docs/developer-kit/bnbagent-sdk/architecture.md
@@ -109,14 +109,17 @@ High-level facade over three contracts. Most callers only touch `ERC8183Client`.
 | `negotiation.py` | `NegotiationHandler`, structured description schema, quote expiry |
 | `schema.py` | `DeliverableManifest`, `JobDescription`, `SCHEMA_VERSION` — on-chain description and off-chain deliverable JSON |
 | `constants.py` | `get_erc8183_config()` — per-network defaults |
-| `module.py` | `ERC8183Module` plugin |
+| `job_ops.py` | `ERC8183JobOps` — async wrapper over `ERC8183Client`; incremental scan for newly funded jobs; `submit_result` for deliverable submission. Also exports `funded_job_watcher` |
 
-### `bnbagent/erc8183/server/` — FastAPI Integration
+### HTTP serving — reference example, not SDK API
 
-| File | Purpose |
-|------|---------|
-| `routes.py` | `create_erc8183_app()` FastAPI factory; `ERC8183State`; `/erc8183/job/{id}`, `/erc8183/negotiate`, `/erc8183/status`, `/erc8183/health`; funded-job background poll loop when `on_job` is provided |
-| `job_ops.py` | `ERC8183JobOps` — async wrapper over `ERC8183Client`; incremental scan for newly funded jobs; `submit_result` for deliverable submission |
+The SDK is transport-agnostic and ships **no** FastAPI layer. The `create_erc8183_app()`
+factory, its routes, and the funded-job poll wiring live in the reference example at
+[`python/examples/agent-server/src/erc8183_server.py`](https://github.com/bnb-chain/bnbagent-sdk/tree/main/python/examples/agent-server) —
+copy that directory and own it.
+
+The SDK underneath provides only the headless primitives the example is built on:
+`ERC8183JobOps`, `funded_job_watcher`, `NegotiationHandler`, and `SlidingWindowLimiter`.
 
 ### `bnbagent/wallets/` — Wallet Providers
 
@@ -168,7 +171,7 @@ from bnbagent.erc8183 import (
     ERC8183Client, CommerceClient, RouterClient, PolicyClient,
     JobStatus, Verdict, Job,
 )
-from bnbagent.erc8183.server import create_erc8183_app, ERC8183JobOps
+from bnbagent.erc8183 import ERC8183JobOps, funded_job_watcher
 from bnbagent.erc8183.config import ERC8183Config
 from bnbagent.storage import LocalStorageProvider, IPFSStorageProvider
 ```

--- a/docs/developer-kit/bnbagent-sdk/architecture.md
+++ b/docs/developer-kit/bnbagent-sdk/architecture.md
@@ -11,8 +11,8 @@ to start.
 ## Bird's Eye View
 
 BNB Agent SDK is a Python toolkit for building **on-chain AI agents** on
-BNB Chain. It provides wallet management, a plugin module system, off-chain
-storage abstraction, and built-in support for the following protocols:
+BNB Chain. It provides wallet management, independent protocol subpackages,
+off-chain storage abstraction, and built-in support for the following protocols:
 
 - **ERC-8004** — On-chain identity registry for AI agents (register, discover,
   resolve endpoints).
@@ -26,36 +26,29 @@ storage abstraction, and built-in support for the following protocols:
     dispute window is implicit approval; a client can raise a dispute
     that the whitelisted voters resolve by `voteReject` reaching quorum.
 
-The SDK is organized as a **plugin system**: each protocol is a self-contained
-module that can be used independently or composed via the `BNBAgent` facade.
-New protocols can be added as modules without modifying the SDK core.
+The SDK is organized as **independent subpackages**: each protocol is
+self-contained and imported directly. There is no central facade or registry —
+callers compose the pieces they need.
 Wallet signing and off-chain storage are abstracted behind provider interfaces,
 making the SDK backend-agnostic.
 
 ```
-                    ┌─────────────┐
-                    │  BNBAgent   │  optional facade (main.py)
-                    │  from_env() │
-                    └──────┬──────┘
-                           │ discovers & initializes
-              ┌────────────┼────────────┐
-              │            │            │
-        ┌─────▼─────┐ ┌───▼────┐ ┌────▼─────┐
-        │  erc8004  │ │  erc8183  │ │ wallets  │
-        │  Identity │ │  v1    │ │ Signing  │
-        └─────┬─────┘ └───┬────┘ └────┬─────┘
-              │           │           │
-              └────┬──────┘           │
-                   │                  │
-            ┌──────▼──────┐    ┌──────▼──────┐
-            │    core     │    │ storage_    │
-            │ (infra)     │    │ providers   │
-            └─────────────┘    └─────────────┘
+        ┌───────────┐ ┌───────────┐ ┌───────────┐
+        │  erc8004  │ │  erc8183  │ │  wallets  │
+        │ Identity  │ │    v1     │ │  Signing  │
+        └─────┬─────┘ └─────┬─────┘ └─────┬─────┘
+              │             │             │
+              └──────┬──────┘             │
+                     │                    │
+              ┌──────▼──────┐      ┌──────▼──────┐
+              │    core     │      │   storage   │
+              │  (infra)    │      │  providers  │
+              └─────────────┘      └─────────────┘
 ```
 
 Arrows point **downward** — upper layers depend on lower layers, never the
 reverse. `erc8183` depends on `erc8004` (for agent discovery). Both protocol
-modules depend on `core` for transaction management.
+subpackages depend on `core` for transaction management.
 
 ## Code Map
 
@@ -64,19 +57,16 @@ modules depend on `core` for transaction management.
 | File | Purpose |
 |------|---------|
 | `__init__.py` | Tier 1 public API (re-exports from subpackages) |
-| `main.py` | `BNBAgent` — optional high-level facade over the module system |
-| `config.py` | `BNBAgentConfig`, `NetworkConfig`, `NETWORKS` registry, `resolve_network()` |
+| `config.py` | `NetworkConfig`, `NETWORKS` registry, `resolve_network()` |
 | `constants.py` | Global constants (`SCAN_API_URL`) |
 | `exceptions.py` | `BNBAgentError` hierarchy |
 
 ### `bnbagent/core/` — Internal Infrastructure
 
-Not part of the public API. Provides shared plumbing for protocol modules.
+Not part of the public API. Provides shared plumbing for the protocol subpackages.
 
 | File | Purpose |
 |------|---------|
-| `module.py` | `BNBAgentModule` ABC and `ModuleInfo` dataclass |
-| `registry.py` | `ModuleRegistry` — discovery (built-in + entry points), dependency validation, topological initialization |
 | `contract_mixin.py` | `ContractClientMixin` — shared base for `CommerceClient`, `RouterClient`, `PolicyClient`, `MinimalERC20Client` (tx signing, nonce management, retry with backoff) |
 | `nonce_manager.py` | `NonceManager` — per-account thread-safe nonce tracking with chain re-sync |
 | `multicall.py` | `multicall_read()` — Multicall3 batch view helper |
@@ -91,7 +81,6 @@ Not part of the public API. Provides shared plumbing for protocol modules.
 | `contract.py` | `ContractInterface` — low-level web3 contract calls |
 | `models.py` | `AgentEndpoint` dataclass |
 | `constants.py` | `get_erc8004_config()` — per-network contract addresses |
-| `module.py` | `ERC8004Module` plugin |
 
 ### `bnbagent/erc8183/` — ERC-8183 Protocol
 
@@ -157,7 +146,7 @@ services; no live chain calls in CI.
 
 ```python
 from bnbagent import (
-    BNBAgent, BNBAgentConfig, NetworkConfig, BNBAgentError,
+    NetworkConfig, BNBAgentError,
     ERC8004Agent, AgentEndpoint,
     WalletProvider, EVMWalletProvider,
     ERC8183Client, JobStatus, Verdict,
@@ -176,28 +165,6 @@ from bnbagent.erc8183.config import ERC8183Config
 from bnbagent.storage import LocalStorageProvider, IPFSStorageProvider
 ```
 
-## Module System
-
-The SDK uses a plugin architecture. Every protocol is a `BNBAgentModule`
-subclass discovered and managed by `ModuleRegistry`.
-
-**Lifecycle:**
-
-1. `discover()` — imports built-in modules (`erc8004`, `erc8183`) + scans
-   `bnbagent.modules` entry-point group for third-party plugins
-2. `validate_dependencies()` — ensures all declared dependencies are present
-3. `_topological_sort()` — orders modules so dependencies initialize first
-4. `initialize_all(config)` — calls `module.initialize()` in order
-5. `shutdown_all()` — cleanup in reverse order
-
-**Extending:** implement `BNBAgentModule`, expose a `create_module()` factory,
-and register via `pyproject.toml` entry points:
-
-```toml
-[project.entry-points."bnbagent.modules"]
-my_module = "my_package:create_module"
-```
-
 ## Configuration
 
 ```
@@ -207,10 +174,8 @@ NetworkConfig (NETWORKS dict in config.py)
 
 resolve_network(name) + env var overrides
   ↓ (clients assert w3.eth.chain_id == nc.chain_id at init — wrong RPC → ValueError)
-BNBAgentConfig
-  ├── wallet_provider  (explicit or auto-wrapped from private_key)
-  ├── settings         (general key-value)
-  └── modules          (namespaced: {"erc8183": {"commerce_address": "<override>"}})
+ERC8183Config
+  └── wallet_provider  (explicit or auto-wrapped from private_key)
 ```
 
 **Environment variable overrides** (module-scoped):
@@ -233,7 +198,7 @@ name), env overrides are **not** applied — the object is used as-is.
 Commerce settlement assets are resolved at runtime from the deployed kernel
 via `ERC8183Client` — not duplicated in this documentation.
 
-Both `BNBAgentConfig` and `ERC8183Config` support the convenience pattern:
+`ERC8183Config` supports the convenience pattern:
 pass `private_key` + `wallet_password` and the config auto-wraps them into
 an `EVMWalletProvider`, then **clears both the plaintext key and password**
 from the config object (the provider keeps its own password copy).
@@ -245,9 +210,6 @@ These properties hold across the codebase and should be preserved:
 - **No plaintext secrets in config after construction.** `__post_init__()` wraps
   `private_key` into a `WalletProvider` and zeros both the `private_key` and
   `wallet_password` string fields (the provider retains its own password copy).
-- **Modules never import each other directly.** Inter-module communication
-  goes through the registry or shared config. Module dependencies are declared
-  in `ModuleInfo.dependencies` and enforced at initialization.
 - **`ContractClientMixin` prefers `wallet_provider` over raw `private_key`.**
 - **Storage providers are async.** Synchronous callers use `upload_sync()`
   to avoid blocking the event loop.
@@ -335,14 +297,14 @@ BNBAgentError
   multisig, or MPC signers.
 - **Custom StorageProvider** — implement the `StorageProvider` ABC for
   alternative backends (S3, Arweave, etc.).
-- **Custom Module** — extend `BNBAgentModule` and register via entry points
-  to add new protocol support without modifying the SDK.
 
 ## Dependencies
 
 | Category | Packages |
 |----------|----------|
 | Core | `web3 ≥ 6.15`, `eth-account ≥ 0.10`, `python-dotenv ≥ 1.0`, `requests ≥ 2.31` |
-| Server (optional) | `fastapi ≥ 0.104`, `uvicorn ≥ 0.24` |
-| IPFS (optional) | `httpx ≥ 0.25` |
-| Dev | `pytest`, `pytest-mock`, `pytest-asyncio`, `ruff` |
+| `examples` (extra) | `fastapi ≥ 0.104`, `uvicorn ≥ 0.24`, `python-dotenv ≥ 1.0`, `aiosqlite ≥ 0.19`, `ddgs ≥ 6.0` |
+| `ipfs` (extra) | `httpx ≥ 0.25` |
+| `dev` (extra) | `pytest ≥ 7.4`, `pytest-mock ≥ 3.11`, `pytest-asyncio ≥ 0.23`, `ruff ≥ 0.4`, `httpx ≥ 0.25` |
+
+The extras are exactly `examples`, `ipfs`, and `dev` — there is no `server` extra.

--- a/docs/developer-kit/bnbagent-sdk/examples.md
+++ b/docs/developer-kit/bnbagent-sdk/examples.md
@@ -6,8 +6,8 @@ Runnable scripts in the [bnbagent-sdk](https://github.com/bnb-chain/bnbagent-sdk
 
 | Example | Role | Description |
 |---------|------|-------------|
-| [examples/client/](https://github.com/bnb-chain/bnbagent-sdk/tree/main/examples/client/) | Client | Five stand-alone scripts for the canonical ERC-8183 flows: happy / dispute-reject / stalemate-expire / never-submit / cancel-open. |
-| [examples/voter/](https://github.com/bnb-chain/bnbagent-sdk/tree/main/examples/voter/) | Voter | `voteReject` script + `Disputed` event watcher for whitelisted voters. |
-| [examples/agent-server/](https://github.com/bnb-chain/bnbagent-sdk/tree/main/examples/agent-server/) | Provider | FastAPI agent that searches blockchain news via DuckDuckGo. Demonstrates `create_erc8183_app()`, the funded-job poll loop, and ERC-8004 registration. |
+| [examples/client/](https://github.com/bnb-chain/bnbagent-sdk/tree/main/python/examples/client/) | Client | Five stand-alone scripts for the canonical ERC-8183 flows: happy / dispute-reject / stalemate-expire / never-submit / cancel-open. |
+| [examples/voter/](https://github.com/bnb-chain/bnbagent-sdk/tree/main/python/examples/voter/) | Voter | `voteReject` script + `Disputed` event watcher for whitelisted voters. |
+| [examples/agent-server/](https://github.com/bnb-chain/bnbagent-sdk/tree/main/python/examples/agent-server/) | Provider | FastAPI agent that searches blockchain news via DuckDuckGo. Demonstrates `create_erc8183_app()`, the funded-job poll loop, and ERC-8004 registration. |
 
 [← BNB Agent SDK overview](index.md)

--- a/docs/developer-kit/bnbagent-sdk/index.md
+++ b/docs/developer-kit/bnbagent-sdk/index.md
@@ -143,8 +143,8 @@ OPEN ──► FUNDED ──► SUBMITTED ──┬──► (silence past windo
 | Guide | Description |
 |-------|-------------|
 | [Quickstart](quickstart.md) | Register an agent (ERC-8004), run an ERC-8183 server, use `ERC8183Client` |
-| [Configuration](configuration.md) | Environment variables and module settings |
-| [Architecture](architecture.md) | Code map, module system, data flows |
+| [Configuration](configuration.md) | Environment variables and client configuration |
+| [Architecture](architecture.md) | Code map, subpackage layout, data flows |
 | [Networks & contracts](networks.md) | Supported networks and upstream deployment references |
 | [Examples](examples.md) | Client, voter, and agent-server examples |
 | [Security](security.md) | Wallet handling, signing policy, x402 |

--- a/docs/developer-kit/bnbagent-sdk/index.md
+++ b/docs/developer-kit/bnbagent-sdk/index.md
@@ -26,15 +26,20 @@ pip install bnbagent
 The base package includes ERC-8004 identity registration and the ERC-8183 client stack. Install optional extras for additional features:
 
 ```bash
-# ERC-8183 server components (FastAPI + Uvicorn)
-pip install "bnbagent[server]"
-
 # IPFS storage (HTTP pinning service backend, e.g. Pinata)
 pip install "bnbagent[ipfs]"
 
+# Dependencies used by the runnable examples (FastAPI, Uvicorn, python-dotenv)
+pip install "bnbagent[examples]"
+
 # All extras
-pip install "bnbagent[server,ipfs]"
+pip install "bnbagent[ipfs,examples]"
 ```
+
+!!! note "There is no `server` extra"
+    The SDK ships headless primitives only (`ERC8183JobOps`, `funded_job_watcher`,
+    `NegotiationHandler`). The FastAPI serving layer is reference example code you copy
+    and own — see [Run an ERC-8183 Agent Server](quickstart.md#quick-start-run-an-erc-8183-agent-server).
 
 ## What is ERC-8004?
 
@@ -153,7 +158,7 @@ OPEN ──► FUNDED ──► SUBMITTED ──┬──► (silence past windo
 
 ```bash
 pip install bnbagent
-pip install "bnbagent[server,ipfs]"  # optional extras
+pip install "bnbagent[ipfs,examples]"  # optional extras
 ```
 
 [PyPI](https://pypi.org/project/bnbagent/)

--- a/docs/developer-kit/bnbagent-sdk/quickstart.md
+++ b/docs/developer-kit/bnbagent-sdk/quickstart.md
@@ -51,14 +51,21 @@ Set up an agent server that accepts jobs, processes work, and gets paid.
 
 ### Prerequisites
 
-- `pip install "bnbagent[server,ipfs]"`
-- A `.env` file with your credentials (see [examples/agent-server/.env.example](https://github.com/bnb-chain/bnbagent-sdk/tree/main/examples/agent-server/.env.example))
+- `pip install "bnbagent[ipfs,examples]"`
+- A `.env` file with your credentials (see [python/examples/agent-server/.env.example](https://github.com/bnb-chain/bnbagent-sdk/tree/main/python/examples/agent-server/.env.example))
+
+!!! important "`create_erc8183_app` is reference example code, not SDK API"
+    The SDK is transport-agnostic and ships no FastAPI layer. The factory used below lives in
+    [`python/examples/agent-server/src/erc8183_server.py`](https://github.com/bnb-chain/bnbagent-sdk/tree/main/python/examples/agent-server).
+    Copy that directory into your project and own it — then the imports below resolve against
+    your own copy. The SDK underneath provides only the headless primitives
+    (`ERC8183JobOps`, `funded_job_watcher`, `NegotiationHandler`, `SlidingWindowLimiter`).
 
 ### Option 1: Standalone App (`create_erc8183_app`)
 
 ```python
-# agent.py
-from bnbagent.erc8183.server import create_erc8183_app
+# agent.py — assumes you copied examples/agent-server/src/ into your project
+from erc8183_server import create_erc8183_app
 
 def execute_job(job: dict) -> str:
     """Called automatically for each FUNDED job. Return the deliverable string."""
@@ -95,7 +102,7 @@ uvicorn agent:app --port 8003
 ```python
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
-from bnbagent.erc8183.server import create_erc8183_app
+from erc8183_server import create_erc8183_app
 
 def execute_job(job: dict) -> str:
     return f"Processed: {job['description']}"
@@ -192,6 +199,6 @@ erc8183.vote_reject(job_id)    # whitelisted voter only; after dispute
 erc8183.claim_refund(job_id)   # anyone, after expiredAt, no settlement reached
 ```
 
-See [examples/client/](https://github.com/bnb-chain/bnbagent-sdk/tree/main/examples/client/) for the five canonical flows (happy, dispute-reject, stalemate-expire, never-submit, cancel-open).
+See [examples/client/](https://github.com/bnb-chain/bnbagent-sdk/tree/main/python/examples/client/) for the five canonical flows (happy, dispute-reject, stalemate-expire, never-submit, cancel-open).
 
 ---

--- a/docs/developer-kit/bnbagent-sdk/quickstart.md
+++ b/docs/developer-kit/bnbagent-sdk/quickstart.md
@@ -111,7 +111,7 @@ erc8183_app = create_erc8183_app(on_job=execute_job, prefix="")
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    await erc8183_app.state.startup()
+    erc8183_app.state.startup()  # returns the poll-loop Task — do not await it
     yield
 
 app = FastAPI(lifespan=lifespan)

--- a/docs/developer-kit/bnbagent-sdk/security.md
+++ b/docs/developer-kit/bnbagent-sdk/security.md
@@ -144,8 +144,8 @@ What are you signing?
 | Opt into Permit2 SignatureTransfer | `extend(primary_type_allowlist={"PermitTransferFrom"})` |
 | Widen validity to 30 min | `extend(max_validity_window_seconds=1800)` |
 
-Examples: see [examples/security_e2e.py](https://github.com/bnb-chain/bnbagent-sdk/blob/main/examples/security_e2e.py) (signing + recovery loop, 6 assertions)
-and [examples/x402_buyer_demo.py](https://github.com/bnb-chain/bnbagent-sdk/blob/main/examples/x402_buyer_demo.py) (complete buyer flow with mock 402 server).
+Examples: see [python/examples/security/e2e.py](https://github.com/bnb-chain/bnbagent-sdk/blob/main/python/examples/security/e2e.py) (signing + recovery loop, 6 assertions)
+and [python/examples/x402/buyer_demo.py](https://github.com/bnb-chain/bnbagent-sdk/blob/main/python/examples/x402/buyer_demo.py) (complete buyer flow with mock 402 server).
 
 Full design rationale and threat model: see ADR #30 in the
 [bnbchain-studio](https://github.com/bnb-chain/bnbchain-studio) repo

--- a/docs/developer-kit/bnbagent-sdk/troubleshooting.md
+++ b/docs/developer-kit/bnbagent-sdk/troubleshooting.md
@@ -14,6 +14,6 @@ title: BNB Agent SDK Troubleshooting
 | `408 Job expired` | Past `expiredAt` | Create a new job; client can `claimRefund` the old one. |
 | `402 Budget below service price` | `budget < ERC8183_SERVICE_PRICE` | Client must create a job with a higher budget (visible at `GET /erc8183/status`). |
 | `router.settle` reverts with `policy pending` | Dispute window hasn't elapsed and no dispute was raised | Wait until `policy.check(jobId)` returns a non-PENDING verdict, then retry. |
-| `voteReject` reverts with `not voter` / `not disputed` | Caller not whitelisted, or no dispute exists | Use [examples/voter/vote_reject.py](https://github.com/bnb-chain/bnbagent-sdk/tree/main/examples/voter/vote_reject.py) — it validates before sending. |
+| `voteReject` reverts with `not voter` / `not disputed` | Caller not whitelisted, or no dispute exists | Use [examples/voter/vote_reject.py](https://github.com/bnb-chain/bnbagent-sdk/tree/main/python/examples/voter/vote_reject.py) — it validates before sending. |
 
 ---

--- a/docs/developer-kit/bnbchain-studio/architecture.md
+++ b/docs/developer-kit/bnbchain-studio/architecture.md
@@ -155,7 +155,7 @@ Buyer                    Layer B (Service)              Layer A (Agent)         
 
 ## Further reading
 
-- [BNB Agent SDK architecture](../bnbagent-sdk/architecture.md) — protocol module system
+- [BNB Agent SDK architecture](../bnbagent-sdk/architecture.md) — protocol subpackage layout
 - [GitHub — architecture.md](https://github.com/bnb-chain/bnbagent-studio/blob/main/docs/design/architecture.md) — full design document
 - [GitHub — decisions.md](https://github.com/bnb-chain/bnbagent-studio/blob/main/docs/design/decisions.md) — decision records
 

--- a/docs/developer-kit/bnbchain-studio/security.md
+++ b/docs/developer-kit/bnbchain-studio/security.md
@@ -71,9 +71,14 @@ The MCP server (`bag mcp serve`) exposes 15 tools — all read-only:
 
 ## Budget and auto-topup
 
-`bag budget enable` opts into automatic LLM credit renewal via x402. Requires:
+`bag budget enable` opts into **wallet-funded** LLM credit renewal via x402 — it lets the Agent
+auto-pay $U from your wallet when credits run low. It is **off by default**: a non-interactive
+`bag init` records no `[budget]` section, so wallet-funded renewal stays off until you enable it
+explicitly. This is separate from the managed-model auto-renew hook, which is included at no cost
+and needs no budget. Requires:
 
-- Funded mainnet wallet balance for auto-renew flows
+- Funded BSC **mainnet** U balance for auto-renew flows (Pieverse settles on mainnet only —
+  testnet U cannot pay for LLM credits)
 - `WALLET_PASSWORD` injected at Agent runtime deploy time
 
 Without runtime password injection, the Agent falls back to manual `bag llm allocate`. Disable with `bag budget disable`.

--- a/docs/developer-kit/bnbchain-studio/security.md
+++ b/docs/developer-kit/bnbchain-studio/security.md
@@ -74,14 +74,16 @@ The MCP server (`bag mcp serve`) exposes 15 tools — all read-only:
 `bag budget enable` opts into **wallet-funded** LLM credit renewal via x402 — it lets the Agent
 auto-pay $U from your wallet when credits run low. It is **off by default**: a non-interactive
 `bag init` records no `[budget]` section, so wallet-funded renewal stays off until you enable it
-explicitly. This is separate from the managed-model auto-renew hook, which is included at no cost
-and needs no budget. Requires:
+explicitly. Note that an *interactive* `bag init` does ask (`Enable auto-topup? [Y/n]`) and treats a
+bare Enter as yes — run `bag budget show` if you are unsure which path you took. This is separate
+from the managed-model auto-renew hook (`[llm.auto_renew]`, on by default), which never spends from
+your wallet — it only reallocates credit already sitting in your Pieverse Account Balance. Requires:
 
 - Funded BSC **mainnet** U balance for auto-renew flows (Pieverse settles on mainnet only —
   testnet U cannot pay for LLM credits)
 - `WALLET_PASSWORD` injected at Agent runtime deploy time
 
-Without runtime password injection, the Agent falls back to manual `bag llm allocate`. Disable with `bag budget disable`.
+Without runtime password injection, the Agent falls back to allocate-only mode — no wallet spend, no error. Disable with `bag budget disable`.
 
 ## Audit log
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -214,7 +214,7 @@
 - [Greenfield SDK](https://docs.bnbchain.org/developer-kit/greenfield-sdk/): Go and JavaScript client libraries for Greenfield (language tabs).
 - [BNB Agent SDK](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/): Python SDK for on-chain AI agents (ERC-8004, ERC-8183) on BSC.
   - [Quickstart](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/quickstart/): Register agents, run server, use client.
-  - [Architecture](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/architecture/): Module system and data flows.
+  - [Architecture](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/architecture/): Code map, public API, invariants and data flows.
   - [Configuration](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/configuration/): Environment variables.
   - [Networks & contracts](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/networks/): Supported networks and upstream deployment references.
   - [Examples](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/examples/): Client, voter, and agent-server flows.


### PR DESCRIPTION
> ### 📋 Merge order
> One of four related docs PRs. Recommended sequence:
>
> | # | PR | Depends on |
> |---|---|---|
> | 1 | [#885](https://github.com/bnb-chain/bnb-chain.github.io/pull/885) — Studio Node path + nav order | — |
> | 2 | [#884](https://github.com/bnb-chain/bnb-chain.github.io/pull/884) — TypeScript SDK quickstart | **rebased on #885**; fast-forwards after it |
> | 3 | [#886](https://github.com/bnb-chain/bnb-chain.github.io/pull/886) — Studio architecture | independent |
> | 4 | [#887](https://github.com/bnb-chain/bnb-chain.github.io/pull/887) — remaining Studio pages | independent |
>
> [#882](https://github.com/bnb-chain/bnb-chain.github.io/pull/882) (SDK server-module fixes) is independent of all four.

---

## Summary

The BNB Agent SDK docs reference a `bnbagent.erc8183.server` module and a `server` install extra that **do not exist** in the published package. A developer following the quickstart hits `ModuleNotFoundError` on the first server example.

Verification is source-level against [`bnb-chain/bnbagent-sdk`](https://github.com/bnb-chain/bnbagent-sdk) `main` @ `1f5476b` and the published `bnbagent` **0.4.3** wheel on PyPI. (Note: the repo's `v0.5.1` tag is the TypeScript package `@bnbagent/sdk`; the Python tag for the same tree is `bnbagent-v0.4.3`.)

## Root cause

Two upstream commits, not five unrelated errors:

- **`0523197`** — "drop the built-in REST server (#44)", 2026-07-01, first shipped in `bnbagent-v0.4.0`. Deleted the REST server package **and the entire plugin/module system**, and renamed two example scripts.
- **`010703a`** — monorepo restructure, 2026-08-06. Moved `examples/` → `python/examples/`.

Confirmed on PyPI: the `server` extra is present in 0.3.0 and absent from 0.4.0 onward.

## What was wrong

| # | Claim in docs | Reality in the shipped package |
|---|---|---|
| 1 | `pip install "bnbagent[server,ipfs]"` and `bnbagent[server]` | **No `server` extra.** `python/pyproject.toml` defines only `ipfs`, `dev`, `examples`. pip emits `WARNING: bnbagent 0.4.3 does not provide the extra 'server'` and continues, so FastAPI/Uvicorn never get installed. |
| 2 | `from bnbagent.erc8183.server import create_erc8183_app` | **No such module.** `create_erc8183_app()` lives in `python/examples/agent-server/src/erc8183_server.py:254`. That example's own README states it is *"example code, not SDK API"*. |
| 3 | `architecture.md` documents a `bnbagent/erc8183/server/` package with `routes.py` | That package does not exist. `job_ops.py` is real, but sits at `bnbagent/erc8183/job_ops.py`. |
| 4 | `architecture.md` lists `module.py` / `ERC8183Module` | Neither exists in the package. |
| 5 | Example links to `tree/main/examples/...` | All 404 — the real path is `tree/main/python/examples/...`. |

## Beyond the five: the rest of the class

The five claims above are symptoms of `0523197`. Sweeping the docs for everything that commit deleted or moved turned up more of the same defect:

| # | Defect | Location |
|---|---|---|
| 6 | The **Tier 1 import block was copy-pasteable and raised `ImportError`** — `BNBAgent` and `BNBAgentConfig` are not in upstream `__all__`; `main.py` was deleted by `0523197` and `BNBAgentConfig` was renamed to `AgentConfig` in `core/`. This is the PR's own headline failure mode, 14 lines above the import it originally fixed. | `architecture.md` |
| 7 | The **whole plugin/module system was still documented** — the `main.py` / `core/module.py` / `core/registry.py` / `erc8004/module.py` table rows, the "Module System" section (which instructed readers to register plugins under a `[project.entry-points."bnbagent.modules"]` group absent from `pyproject.toml`), the `ModuleInfo.dependencies` invariant, the "Custom Module" extension point, and the facade box in the architecture diagram. | `architecture.md` |
| 8 | **Two more 404 links — it was eight, not six.** These use `blob/main/examples/` rather than `tree/main/examples/`, and the files were *renamed* as well as moved, so a `python/` prefix alone does not fix them: `python/examples/security/e2e.py` and `python/examples/x402/buyer_demo.py` (both 200). | `bnbagent-sdk/security.md` |
| 9 | **The quickstart block still deadlocked after the import was fixed.** `state.startup` is assigned at `erc8183_server.py:470` as `lambda: _spawn(_funded_poll_loop())` — a sync lambda returning the infinite poll loop's `Task`. Awaiting it means the lifespan never reaches `yield` and uvicorn never serves. Reproduced under Python 3.11. Pre-existing, and mirrored upstream at `service_mount.py:156`. | `quickstart.md` |
| 10 | Stale "module system" prose that names no symbol, so a symbol grep misses it. | `architecture.md`, `index.md`, `bnbchain-studio/architecture.md` |
| 11 | The dependencies table advertised a `Server (optional)` extra, contradicting the "no `server` extra" note added by this PR. | `architecture.md` |

## Changes

- **`index.md`** — replaced the phantom `server` extra with the real `examples` extra (which carries FastAPI/Uvicorn/python-dotenv/ddgs/aiosqlite); added a note that no `server` extra exists; retitled the doc-table rows that referred to a module system.
- **`quickstart.md`** — added an admonition explaining `create_erc8183_app` is reference example code to copy; corrected both imports to `from erc8183_server import ...`; **dropped the `await` on `erc8183_app.state.startup()`** with a comment on why.
- **`architecture.md`** — removed the deleted plugin/module system in full (table rows, "Module System" section, invariant, extension point, diagram facade, prose); fixed the Tier 1 import block; corrected the config-flow diagram to `ERC8183Config`; rewrote the dependencies table to the three real extras with their actual contents.
- **`bnbagent-sdk/security.md`** — repointed the two remaining 404 links to their renamed paths.
- **`bnbchain-studio/architecture.md`** — "protocol module system" → "protocol subpackage layout".
- **`bnbchain-studio/security.md`** — `bag budget enable` opts into *wallet-funded* renewal and is off by default; **corrected "included at no cost"**, which no shipped artifact supports (the managed-model hook never spends from the wallet, but it draws down the prepaid Pieverse Account Balance; it is $0 only on the default `auto/free` model); noted that an *interactive* `bag init` prompts `[Y/n]` and treats bare Enter as yes; corrected the fallback from "manual `bag llm allocate`" to allocate-only mode. Verified against npm `@bnbagent/studio-cli` 0.0.12 — the package `bnbchain-studio/index.md:27` tells users to install. The GitHub repo 404s, but the CLI is published.

## Verification

The original check here grepped `docs/` for the three strings this PR removes, so it could only ever return clean. Replaced with checks derived from the root-cause commits:

```bash
# every symbol the two drift commits deleted or moved
grep -rnE 'BNBAgentModule|ModuleRegistry|ModuleInfo|ERC8004Module|ERC8183Module|create_module|bnbagent\.modules|BNBAgentConfig|\bBNBAgent\b|main\.py|registry\.py' docs/developer-kit/bnbagent-sdk/

# the vocabulary, not just the identifiers — deleted concepts leave prose behind
grep -rniE 'module system|plugin module|plugin system|plugin architecture' docs/

# both link forms, not just tree/
grep -rnoE 'bnbagent-sdk/(blob|tree)/main/examples[^)]*' docs/
```

All three return no matches on this branch. Every `bnbagent-sdk` example link in the doc set was status-checked; all resolve.

## Known issue, tracked separately

`docs/developer-kit/bnbchain-studio/*.md` contains **15 links to `github.com/bnb-chain/bnbagent-studio`**, which returns 404 — including one in `bnbchain-studio/security.md`, a file this PR edits. Counted at this head: `demo.md` 6, `architecture.md` 2, `deployment.md` 2, `troubleshooting.md` 2, `index.md` 1, `cli-reference.md` 1, `security.md` 1. Out of scope here; follow-up PR to come. Note the `bag` CLI itself *is* public on npm, so if that repo is staying private those links may want to point at the package rather than be removed.

`docs/llms.txt:217` also still reads "Module system and data flows". That file is generated (`chore(llms): sync llms index`), so it needs a sync re-run rather than a hand-edit — folding into the same follow-up.

## Limits

Verification is source-level and against published package metadata. The `ModuleNotFoundError` and the `await` deadlock were reproduced from the code and a stdlib repro, not by installing `bnbagent` and running the quickstart end to end.

## Note on the SDK's own README

`python/README.md` in the SDK repo already says `pip install "bnbagent[ipfs]"` correctly — the drift was only in these docs.