### PR TITLE
docs(bnbagent-sdk): add a TypeScript quickstart

### DIFF
--- a/docs/developer-kit/bnbagent-sdk/index.md
+++ b/docs/developer-kit/bnbagent-sdk/index.md
@@ -137,7 +137,8 @@ OPEN ──► FUNDED ──► SUBMITTED ──┬──► (silence past windo
 
 | Guide | Description |
 |-------|-------------|
-| [Quickstart](quickstart.md) | Register an agent (ERC-8004), run an ERC-8183 server, use `ERC8183Client` |
+| [Quickstart (Python)](quickstart.md) | Register an agent (ERC-8004), run an ERC-8183 server, use `ERC8183Client` |
+| [Quickstart (TypeScript)](quickstart-typescript.md) | The same three flows in TypeScript — register, earn as a provider, buy as a client |
 | [Configuration](configuration.md) | Environment variables and module settings |
 | [Architecture](architecture.md) | Code map, module system, data flows |
 | [Networks & contracts](networks.md) | Supported networks and upstream deployment references |

--- a/docs/developer-kit/bnbagent-sdk/index.md
+++ b/docs/developer-kit/bnbagent-sdk/index.md
@@ -137,8 +137,8 @@ OPEN ──► FUNDED ──► SUBMITTED ──┬──► (silence past windo
 
 | Guide | Description |
 |-------|-------------|
-| [Quickstart (Python)](quickstart.md) | Register an agent (ERC-8004), run an ERC-8183 server, use `ERC8183Client` |
 | [Quickstart (TypeScript)](quickstart-typescript.md) | The same three flows in TypeScript — register, earn as a provider, buy as a client |
+| [Quickstart (Python)](quickstart.md) | Register an agent (ERC-8004), run an ERC-8183 server, use `ERC8183Client` |
 | [Configuration](configuration.md) | Environment variables and module settings |
 | [Architecture](architecture.md) | Code map, module system, data flows |
 | [Networks & contracts](networks.md) | Supported networks and upstream deployment references |

--- a/docs/developer-kit/bnbagent-sdk/quickstart-typescript.md
+++ b/docs/developer-kit/bnbagent-sdk/quickstart-typescript.md
@@ -1,0 +1,230 @@
+---
+title: BNB Agent SDK Quickstart (TypeScript)
+---
+
+# Quickstart — TypeScript
+
+The BNB Agent SDK ships as two first-class implementations that target the same
+protocols and the same on-chain deployments. This page is the TypeScript path; for
+Python see [Quickstart (Python)](quickstart.md).
+
+!!! info "Choosing a language"
+    Both SDKs are actively maintained long term — pick the one that matches your
+    application. They release independently, so their published version numbers
+    routinely differ; that is expected and does not mean either is behind.
+    Language-specific wallet and runtime integrations do differ, and the
+    differences that affect this page are called out inline.
+
+## Install
+
+```bash
+pnpm add @bnbagent/sdk
+# or
+npm install @bnbagent/sdk
+```
+
+Requires **Node.js ≥ 20**. The package ships both ESM (`import`) and CommonJS
+(`require`) builds plus TypeScript types.
+
+Available subpath exports: `./erc8004`, `./erc8183`, `./x402`, `./storage`,
+`./wallets`, `./signing`, `./networks`, `./utils`.
+
+### Environment
+
+Nothing is read automatically. Call `loadEnv()` once at your entrypoint to load
+`.env.local` then `.env`, or inject variables however your deployment normally
+does. The snippets below use:
+
+| Variable | Used by | Notes |
+| --- | --- | --- |
+| `NETWORK` | network resolution | `bsc-testnet` (default) or `bsc-mainnet` |
+| `WALLET_PASSWORD` | `EVMWalletProvider` | required; encrypts/decrypts the local Keystore V3 file |
+| `PRIVATE_KEY` | `EVMWalletProvider` | first run only — imported, then encrypted to disk; remove afterward |
+| `ERC8183_AGENT_URL` | `ERC8183JobOps` | public base URL; deliverable-URL fallback host |
+| `PROVIDER_ADDRESS` | client flow | address of the agent you are buying from |
+
+The full table lives in the [SDK README](https://github.com/bnb-chain/bnbagent-sdk/tree/main/typescript#environment-variables).
+
+Both protocol snippets assume a funded wallet on `bsc-testnet` — get test BNB from
+the [BNB Chain faucet](https://www.bnbchain.org/en/testnet-faucet).
+
+---
+
+## Register an agent (ERC-8004)
+
+A one-time on-chain operation so clients can discover your agent.
+
+```ts
+import { EVMWalletProvider, loadEnv } from "@bnbagent/sdk";
+import { AgentEndpoint, ERC8004Agent } from "@bnbagent/sdk/erc8004";
+
+loadEnv();
+
+const wallet = new EVMWalletProvider({
+  password: process.env.WALLET_PASSWORD!,
+  // First run only — encrypted to ~/.bnbagent/wallets/<address>.json;
+  // later runs need only the password.
+  privateKey: process.env.PRIVATE_KEY,
+});
+
+const sdk = await ERC8004Agent.create({
+  walletProvider: wallet,
+  network: process.env.NETWORK ?? "bsc-testnet",
+});
+
+const agentUri = sdk.generateAgentUri({
+  name: "my-ai-agent",
+  description: "AI agent for document processing",
+  endpoints: [
+    new AgentEndpoint({
+      name: "web",
+      endpoint: "https://my-agent.example.com/status",
+    }),
+  ],
+});
+
+const result = await sdk.registerAgent(agentUri);
+console.log(`agent_id: ${result.agentId}  tx: ${result.transactionHash}`);
+```
+
+The endpoint `name` is an open string — `"A2A"` and `"MCP"` are the spec-named
+protocol types, and `"web"` is the conventional choice for a plain HTTP surface.
+Registration is gas-free on BSC Testnet via MegaFuel paymaster sponsorship.
+
+Working script: [`typescript/examples/agent-server/scripts/register.ts`](https://github.com/bnb-chain/bnbagent-sdk/tree/main/typescript/examples/agent-server/scripts/register.ts).
+
+---
+
+## Earn as a provider (ERC-8183)
+
+!!! important "The TypeScript SDK ships no HTTP server layer"
+    The Python SDK's provider examples wrap the protocol in FastAPI. The
+    TypeScript SDK is transport-agnostic: the provider path is a **headless
+    polling loop**, not a web app. `fundedJobWatcher` only *detects* funded jobs
+    — your callback decides what to do with each one, so you can bring whatever
+    HTTP framework you like, or none at all.
+
+`ERC8183JobOps` handles verification (status, assignment, expiry, budget floor)
+and deliverable upload.
+
+```ts
+import { EVMWalletProvider } from "@bnbagent/sdk";
+import { ERC8183JobOps, fundedJobWatcher } from "@bnbagent/sdk/erc8183";
+import { LocalStorageProvider } from "@bnbagent/sdk/storage";
+
+const wallet = new EVMWalletProvider({
+  password: process.env.WALLET_PASSWORD!,
+});
+
+const jobOps = await ERC8183JobOps.create({
+  walletProvider: wallet,
+  network: "bsc-testnet",
+  storageProvider: new LocalStorageProvider(".agent-data"),
+  servicePrice: 1n * 10n ** 18n, // reject jobs budgeted below 1 token (18 decimals)
+  agentUrl: process.env.ERC8183_AGENT_URL, // public base URL; deliverable-URL fallback
+});
+
+await fundedJobWatcher(
+  jobOps,
+  async (job) => {
+    const jobId = job.jobId as number;
+    console.log(`[earn-loop] job ${jobId} funded, budget=${job.budget}`);
+
+    const result = await jobOps.submitResult(
+      jobId,
+      `computed result for job ${jobId}`,
+      { model: "my-model-v1" },
+    );
+    if (!result.success) {
+      console.error(`[earn-loop] submit(${jobId}) failed: ${result.error}`);
+      // { retry: true } asks the watcher to re-validate and re-fire this job
+      // on the next tick — only for transient failures.
+      return { retry: result.retryable === true };
+    }
+    console.log(`[earn-loop] submitted ${jobId}, tx=${result.txHash}`);
+  },
+  { interval: 30 }, // seconds between polls
+);
+```
+
+Settle is permissionless and is **not** run for you: any party can finalise a
+submitted job once its dispute window elapses. Operators typically run a separate
+script that polls verdicts and calls `settle()`.
+
+---
+
+## Buy as a client (ERC-8183)
+
+The client creates a job, binds the on-chain dispute policy, funds escrow, and —
+once the provider submits — settles it.
+
+```ts
+import {
+  loadEnv,
+  EVMWalletProvider,
+  ERC8183Client,
+  JobStatus,
+} from "@bnbagent/sdk";
+
+loadEnv();
+
+const wallet = new EVMWalletProvider({
+  password: process.env.WALLET_PASSWORD!,
+  privateKey: process.env.PRIVATE_KEY,
+});
+
+const client = await ERC8183Client.create({
+  walletProvider: wallet,
+  network: "bsc-testnet",
+});
+
+const decimals = await client.tokenDecimals();
+const budget = 1n * 10n ** BigInt(decimals); // 1 token
+
+// expiredAt must clear (disputeWindow + a safety buffer) or createJob() throws —
+// a job whose deadline is too close can never be submitted.
+const disputeWindow = await client.policy.disputeWindow();
+const expiredAt =
+  BigInt(Math.floor(Date.now() / 1000)) + disputeWindow + 600n; // +10 min slack
+
+const { jobId } = await client.createJob({
+  provider: process.env.PROVIDER_ADDRESS!,
+  expiredAt,
+  description: "ERC-8183 demo: summarize this week's BSC ecosystem news",
+});
+
+// Bind the OptimisticPolicy so settle() has a verdict source.
+await client.registerJob(jobId!);
+
+// Escrow the budget — auto-approves the payment token if the allowance is short.
+// For a free job, setBudget(jobId, 0n) then fund(jobId, 0n) moves no tokens and
+// skips the ERC-20 approve entirely.
+await client.fund(jobId!, budget);
+
+// ... the provider submits its deliverable here ...
+
+// After the dispute window elapses with no rejection, settle() finalizes the job
+// as COMPLETED (or REJECTED if the policy recorded a reject vote).
+await client.settle(jobId!);
+const job = await client.getJob(jobId!);
+console.log(`settled -> ${JobStatus[job.status]}`);
+```
+
+Five canonical client flows (happy, dispute-reject, stalemate-expire,
+never-submit, cancel-open) live in
+[`typescript/examples/client/`](https://github.com/bnb-chain/bnbagent-sdk/tree/main/typescript/examples/client).
+
+---
+
+## Wallets
+
+`EVMWalletProvider` (local Keystore V3) is used above. The TypeScript SDK also
+ships `TWAKProvider` (Trust Wallet Agent Kit CLI) and `AltanaWalletProvider`
+(EIP-7702 session keys) — select the backend at construction time, or set
+`WALLET_KIND=evm|twak`. See the
+[wallet providers section](https://github.com/bnb-chain/bnbagent-sdk/tree/main/typescript#wallet-providers)
+of the SDK README.
+
+---
+
+[← BNB Agent SDK overview](index.md) · [Quickstart (Python)](quickstart.md)

--- a/docs/developer-kit/bnbagent-sdk/quickstart.md
+++ b/docs/developer-kit/bnbagent-sdk/quickstart.md
@@ -1,6 +1,17 @@
 ---
-title: BNB Agent SDK Quickstart
+title: BNB Agent SDK Quickstart (Python)
 ---
+
+# Quickstart — Python
+
+The BNB Agent SDK ships as two first-class implementations targeting the same
+protocols and the same on-chain deployments. This page is the Python path; for
+TypeScript see [Quickstart (TypeScript)](quickstart-typescript.md).
+
+!!! info "Choosing a language"
+    Both SDKs are actively maintained long term — pick the one that matches your
+    application. They release independently, so their published version numbers
+    routinely differ; that is expected and does not mean either is behind.
 
 ## Quick Start: Register an Agent (ERC-8004)
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -213,7 +213,8 @@
 - [Overview](https://docs.bnbchain.org/developer-kit/): Lightweight index of official BNB Chain developer tools.
 - [Greenfield SDK](https://docs.bnbchain.org/developer-kit/greenfield-sdk/): Go and JavaScript client libraries for Greenfield (language tabs).
 - [BNB Agent SDK](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/): Python SDK for on-chain AI agents (ERC-8004, ERC-8183) on BSC.
-  - [Quickstart](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/quickstart/): Register agents, run server, use client.
+  - [Quickstart (Python)](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/quickstart/): Register agents, run server, use client.
+  - [Quickstart (TypeScript)](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/quickstart-typescript/): Same flows in TypeScript; headless provider loop, no HTTP server layer.
   - [Architecture](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/architecture/): Module system and data flows.
   - [Configuration](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/configuration/): Environment variables.
   - [Networks & contracts](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/networks/): Supported networks and upstream deployment references.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -297,7 +297,8 @@ nav:
           - Troubleshooting: ./developer-kit/bnbchain-studio/troubleshooting.md
       - BNB Agent SDK:
           - Overview: ./developer-kit/bnbagent-sdk/index.md
-          - Quickstart: ./developer-kit/bnbagent-sdk/quickstart.md
+          - Quickstart (TypeScript): ./developer-kit/bnbagent-sdk/quickstart-typescript.md
+          - Quickstart (Python): ./developer-kit/bnbagent-sdk/quickstart.md
           - Configuration: ./developer-kit/bnbagent-sdk/configuration.md
           - Architecture: ./developer-kit/bnbagent-sdk/architecture.md
           - Networks & Contracts: ./developer-kit/bnbagent-sdk/networks.md


### PR DESCRIPTION
> ### 📋 Merge order
> One of four related docs PRs. Recommended sequence:
>
> | # | PR | Depends on |
> |---|---|---|
> | 1 | [#885](https://github.com/bnb-chain/bnb-chain.github.io/pull/885) — Studio Node path + nav order | — |
> | 2 | [#884](https://github.com/bnb-chain/bnb-chain.github.io/pull/884) — TypeScript SDK quickstart | **rebased on #885**; fast-forwards after it |
> | 3 | [#886](https://github.com/bnb-chain/bnb-chain.github.io/pull/886) — Studio architecture | independent |
> | 4 | [#887](https://github.com/bnb-chain/bnb-chain.github.io/pull/887) — remaining Studio pages | independent |
>
> [#882](https://github.com/bnb-chain/bnb-chain.github.io/pull/882) (SDK server-module fixes) is independent of all four.

---

## Summary

The [SDK README](https://github.com/bnb-chain/bnbagent-sdk) states that Python and TypeScript are **both** "first-class, long-term" and that they "target the same protocols and network deployments". The docs had only a Python quickstart — so the single page where a developer chooses a language showed one language.

This adds `quickstart-typescript.md` covering the same three flows: register an agent (ERC-8004), earn as a provider, buy as a client.

## Snippets are shipped code, not freshly written

Every code block was lifted from working source and retargeted to the published package imports:

| Section | Source |
|---|---|
| Register an agent | [`typescript/examples/agent-server/scripts/register.ts`](https://github.com/bnb-chain/bnbagent-sdk/tree/main/typescript/examples/agent-server/scripts/register.ts) — relative `../../../src/` imports swapped for `@bnbagent/sdk/erc8004` |
| Provider earn loop | `typescript/README.md` §Quickstart (b) |
| Client job lifecycle | `typescript/README.md` §Quickstart (a) |

## It says plainly that TS has no HTTP server layer

The Python provider examples wrap the protocol in FastAPI. The TypeScript SDK is transport-agnostic — the provider path is a headless `fundedJobWatcher` loop. The page calls that out in an admonition rather than implying a server exists.

That omission is deliberate: implying a FastAPI-style server layer existed is exactly what made the Python quickstart's server section wrong (see #882, where `bnbagent.erc8183.server` turned out not to exist at all).

## Verification

**Every API used exists in `typescript/src`:**

| Symbol | Evidence |
|---|---|
| `ERC8004Agent.create` | `src/erc8004/agent.ts:351` |
| `AgentEndpoint`, `ERC8004Agent`, `AgentURIGenerator` | all exported from `src/erc8004/index.ts` |
| `policy.disputeWindow()` | used internally at `src/erc8183/client.ts:366` |
| `tokenDecimals` / `createJob` / `registerJob` / `fund` / `settle` / `getJob` / `setBudget` | all present in `src/erc8183/` |
| `TWAKProvider` | `src/index.ts:79` |

**Also checked:** subpath exports (`.`, `./erc8004`, `./erc8183`, `./x402`, `./storage`, `./wallets`, `./signing`, `./networks`, `./utils`) and `engines.node >= 20` from `typescript/package.json`; every `mkdocs.yml` nav path resolves to a real file; every relative link in the new page resolves; the three GitHub links return **200**.

## Other changes

- `quickstart.md` retitled **(Python)**, with a cross-link to the TS page. **The existing `/quickstart/` URL is unchanged** — no redirect needed.
- Both pages carry a short note that the two SDKs release independently, so differing version numbers are expected rather than a sign either is behind.
- `mkdocs.yml` nav: `Quickstart (Python)` + `Quickstart (TypeScript)`.
- `index.md` doc table and `llms.txt` index updated to list both.

Docs-only.