### PR TITLE
docs(studio): document the Node path and lead the nav with Studio

### DIFF
--- a/docs/developer-kit/bnbchain-studio/index.md
+++ b/docs/developer-kit/bnbchain-studio/index.md
@@ -4,95 +4,125 @@ title: BNB Agent Studio
 
 # BNB Agent Studio
 
-Scaffold, run, and deploy a **two-layer blockchain seller** on BNB Chain. BNB Agent Studio (`bnbagent-studio`) lets you describe what you want in Claude Code or Cursor; the studio emits a working agent project that **you own**, then helps you develop, debug, and deploy it.
+Describe the agent you want in Claude Code or Cursor; Studio scaffolds a working
+**TypeScript** project that you own, then helps you run, diagnose, and deploy it.
 
-A seller agent earns on-chain by offering services over **ERC-8004** (identity) + **ERC-8183** (commerce) + **x402** (payments), built on the [BNB Agent SDK](https://docs.bnbchain.org/developer-kit/bnbagent-sdk/).
+A seller agent earns on-chain by offering services over **ERC-8004** (identity),
+**ERC-8183** (escrowed commerce), and **x402/B402** (per-request payments), built on
+the [BNB Agent SDK](../bnbagent-sdk/index.md).
 
-> **v0.0.1 is seller-only.** The CLI (`bag`), runtime library (`bnbagent_studio_core`), read-only MCP server, and IDE skills ship today. Buyer product flows and a hosted console are deferred to v2.
+!!! warning "Under active development"
+    Studio manages wallet keys and on-chain funds, and may introduce breaking
+    changes. Start on **BSC testnet** with a wallet funded only for the task.
 
-> ⚠️ This project is under active development and may introduce breaking changes. It manages wallet keys and on-chain funds — start on **testnet** and use at your own risk.
+## Studio vs the SDK
 
-## What you get
+Two layers, and it is worth being clear which one you want:
+
+| | What it is | Reach for it when |
+| --- | --- | --- |
+| **[BNB Agent SDK](../bnbagent-sdk/index.md)** | A **library you import** — ERC-8004, ERC-8183, x402, wallets. Python and TypeScript. | You want full control and will wire the agent yourself. |
+| **BNB Agent Studio** | A **tool that builds and deploys an app for you**, which then imports the SDK. | You want scaffolding, IDE-driven workflow, and a guided path to production. |
+
+## What you install
+
+```bash
+npm install --global @bnbagent/studio-cli
+bag skills install
+```
 
 | Artifact | Package | Purpose |
 |----------|---------|---------|
-| **`bag` CLI** | `@bnbagent/studio-cli` | Scaffold projects, manage wallets, run locally, deploy |
-| **Runtime library** | `bnbagent-studio-core` | Wallet, ERC-8004/8183, x402, signing policy — imported by emitted agent code |
-| **MCP server** | `bnbagent-studio` | 15 read-only chain tools for your IDE |
-| **Skills** | bundled in CLI | 10 procedure playbooks for Claude Code / Cursor |
+| **`bag` CLI** | [`@bnbagent/studio-cli`](https://www.npmjs.com/package/@bnbagent/studio-cli) | Scaffold projects, manage wallets, run locally, deploy |
+| **Agent runtime** | [`@bnbagent/studio-runtime`](https://www.npmjs.com/package/@bnbagent/studio-runtime) | Imported by the generated agent code. The generated project depends on this, **not** on the CLI — removing the global CLI does not disable an already-generated agent. |
+| **Deploy engine** | [`@bnbagent/deploy-cli`](https://www.npmjs.com/package/@bnbagent/deploy-cli) | Pinned; all cloud lifecycle mutations are delegated to it |
+| **IDE skill** | bundled in the CLI | The `/bnbagent-studio` router plus its on-demand playbooks, installed by `bag skills install` |
+| **MCP server** | `bag mcp serve` | 15 read-only chain tools for your IDE — it never signs |
 
-Install one command:
+The bundled skill is the primary interface: it turns your intent into a reviewable
+workflow and drives `bag` for you. `bag` remains available for automation and for
+anyone who prefers direct control.
 
-```bash
-npm install -g @bnbagent/studio-cli
+## One runtime, one signer
+
+A single deployed process serves every selected public face and holds the only key.
+There is no separate keyless service tier.
+
+- **Faces are composable** (`--protocols`): **A2A** (agent card + JSON-RPC on `:9000`),
+  **MCP** (Streamable HTTP at `:8000/mcp`), and **X402** (`/x402`). One seller core and
+  one wallet serve all of them.
+- **Signing is fixed code**, never an LLM-callable tool. It lives in
+  `app/agent/src/signing.ts`. The LLM's chain tools are read-only, and no LLM
+  participates in pricing.
+- **The keystore lives at the workspace root** in `.studio/wallets/` — outside
+  `app/agent/`, so no packaging path can bundle it into a deploy artifact.
+
+The ERC-8183 rail exposes exactly two bounded operations: `negotiate` (a rule-based
+price clamp plus a signed quote) and `notify_funded` (verify the funded job on-chain,
+produce the deliverable, submit it).
+
+## The choices you make
+
+| Dimension | Choices | Notes |
+| --- | --- | --- |
+| Network | `bsc-testnet`, `bsc-mainnet` | Start on testnet. The managed BNB trial is always testnet. |
+| Wallet | `evm-local` (default), `twak`, `altana` | Local encrypted keystore; Trust Wallet Agent Kit custody; or a budget- and time-bounded Altana session. |
+| LLM | Pieverse (default), OpenRouter, OpenAI, Anthropic, Bedrock | Pieverse `auto/free` starts at $0/token. Others use your own credentials. |
+| Commerce rails | ERC-8183, B402, or both | ERC-8183 is job escrow; B402 settles x402 requests. Rails and faces are separate choices. |
+| Public faces | A2A, MCP, X402, or a combination | One runtime serves every selected face. |
+| Deployment | BNB managed trial, AWS AgentCore, Azure Foundry | Every deploy explicitly selects a target; a previous deployment is never a silent default. |
+| Deliverable storage | local or IPFS | Local is for offline development and **fails deployment readiness**. IPFS is durable and deploy-ready. |
+
+Some combinations are rejected before the project changes — Altana does not support
+paid B402 selling, and Azure Foundry currently deploys **A2A scaffolds only**
+(the MCP entrypoint is rejected before a Foundry deploy).
+
+## What gets generated
+
+```text
+weatheragent/
+├── package.json                 workspace marker
+├── pnpm-workspace.yaml
+├── AGENTS.md                    generated safety rules for coding agents
+├── agentcore/
+│   ├── agentcore.json           deployment descriptor
+│   └── aws-targets.json         AWS account and region for self-deploy
+├── .studio/
+│   ├── .env.local               gitignored secrets, mode 0600
+│   └── wallets/                 encrypted keystore, outside deployable code
+└── app/agent/
+    ├── studio.toml              network, wallet, LLM, policy, rails, faces
+    └── src/
+        ├── sellerCore.ts        the work your agent sells  ← you edit this
+        ├── signing.ts           fixed quote / verify / submit path
+        ├── tools.ts             read-only chain tools for the LLM
+        ├── main.ts              A2A/X402 entrypoint
+        ├── mcpMain.ts           MCP-only entrypoint
+        └── dualMain.ts          combined A2A + MCP entrypoint
 ```
 
-## Two-layer deploy model
+Ordinary TypeScript that you own — edit, fork, or move it whenever you want.
 
-AWS Bedrock AgentCore is invoke-only (no public HTTP routes, no background poll loop), so v1 splits the seller into two deployable artifacts:
+## How a seller gets paid
 
-```
-            buyer                                   BNB Chain
-              │ POST /apex/negotiate                   ▲
-              ▼                                        │ funds / settles jobs
-┌──────────────────────────────┐   InvokeAgentRuntime  │
-│  Layer B — ERC-8183 Service  │ ──────────────────►  ┌┴─────────────────────────────┐
-│  app/service/ → EC2/Fargate  │                      │  Layer A — the Agent         │
-│  public · long-running       │ ◄────────────────── │  app/agent/ → AgentCore      │
-│  KEYLESS · no LLM · no sign  │   signed offer /     │  non-public · invoke-only    │
-│  /negotiate + funded-job     │   deliverable        │  the LLM + the SOLE signer   │
-│  poller                      │                      │  quote / fulfill / settle    │
-└──────────────────────────────┘                      └──────────────────────────────┘
-```
+**ERC-8183 — negotiated work with escrow.** A buyer calls `negotiate`; fixed code
+clamps the configured list price and signs a quote. The buyer creates the job, sets a
+budget, and funds escrow, then sends `notify_funded`. The seller verifies the signed
+terms, assigned provider, status, budget, and funded state **on-chain before doing paid
+work**, stores the deliverable, and submits its reference. The buyer then manually
+chooses approve, reject, or dispute — Studio never silently auto-settles a buyer's job.
 
-- **Layer A — the Agent** (`app/agent/` → AWS Bedrock AgentCore): the LLM, memory, tools, and **sole key-holder/signer**. Invoked on action envelopes (`quote` / `fulfill` / `settle`). All signing is fixed entrypoint code — never an LLM-callable tool.
-- **Layer B — the ERC-8183 Service** (`app/service/` → EC2/Fargate): a public, long-running, **keyless** container — `/negotiate` ingress, funded-job poller, and `InvokeAgentRuntime` client. Holds no key, runs no LLM, never signs.
+`price = "0"` is an explicit **FREE** ERC-8183 job: it skips token escrow, though
+state-changing calls still need gas or a sponsored path.
 
-## Relationship to BNB Agent SDK
+**x402 — pay per HTTP request.** The X402 face exposes `/x402`. A positive
+`price_usd` returns a payment challenge and settles through B402 *before* work starts;
+`price_usd = "0"` is anonymous FREE passthrough that bypasses B402 entirely. Paid mode
+needs a complete per-agent B402 merchant setup and an `evm-local` or `twak` payout
+wallet. Payment settles before work, so a later work failure has no automatic refund.
 
-| Layer | Package | Role |
-|-------|---------|------|
-| Protocol | [bnbagent](https://pypi.org/project/bnbagent/) (BNB Agent SDK) | ERC-8004, ERC-8183, wallet ABC — pure protocol clients |
-| Studio core | `bnbagent_studio_core` | Config, workflows, signing policy, audit log |
-| Studio surface | `bag` CLI + MCP + skills + recipes | Scaffolding, ops, IDE integration |
-| Your code | `app/agent/*`, `app/service/*` | Emitted by recipes; you own and edit freely |
+## Next
 
-Use BNB Agent SDK directly when you want full control over protocol integration. Use BNB Agent Studio when you want scaffolding, IDE skills, a two-layer deploy path, and safety defaults out of the box.
-
-## Prerequisites
-
-| Requirement | Why |
-|-------------|-----|
-| Python ≥ 3.10 | CLI and runtime library |
-| Claude Code or Cursor | Studio is driven from your AI tool via skills |
-| Node ≥ 20 + `npm i -g @aws/agentcore` | `bag init` / `bag dev` / `bag deploy agent` shell out to the native AgentCore CLI |
-| A wallet password | `bag init` creates a local encrypted keystore; password lives in `WALLET_PASSWORD` env only |
-
-Optional: testnet funds (only for paid LLM models or on-chain settle — default `auto/free` Pieverse model needs no funds).
-
-## Documentation
-
-| Guide | Description |
-|-------|-------------|
-| [Quickstart](quickstart.md) | Install, scaffold, run locally, first negotiate |
-| [Demo](demo.md) | End-to-end weather-forecast seller walkthrough |
-| [Architecture](architecture.md) | Six-layer stack, recipes, workspace layout |
-| [Configuration](configuration.md) | `studio.toml`, `.env.local`, cross-layer sync |
-| [CLI reference](cli-reference.md) | `bag` command groups and key flags |
-| [Deployment](deployment.md) | Layer A (AgentCore) + Layer B (EC2) deploy path |
-| [Security](security.md) | Keystore posture, signing policy, MCP read-only guarantee |
-| [Troubleshooting](troubleshooting.md) | `bag doctor`, common errors |
-
-## Repository
-
-[https://github.com/bnb-chain/bnbagent-studio](https://github.com/bnb-chain/bnbagent-studio)
-
-## Package
-
-```bash
-npm install -g @bnbagent/studio-cli
-```
-
-[npm — @bnbagent/studio-cli](https://www.npmjs.com/package/@bnbagent/studio-cli) · [PyPI — bnbagent-studio-core](https://pypi.org/project/bnbagent-studio-core/)
-
-[← Developer Kit overview](../index.md)
+- **[Quickstart](quickstart.md)** — install, scaffold, run, and deploy your first agent
+- [Configuration](configuration.md) · [CLI reference](cli-reference.md) · [Deployment](deployment.md)
+- [Security](security.md) · [Troubleshooting](troubleshooting.md)

--- a/docs/developer-kit/bnbchain-studio/index.md
+++ b/docs/developer-kit/bnbchain-studio/index.md
@@ -96,9 +96,9 @@ weatheragent/
         ├── sellerCore.ts        the work your agent sells  ← you edit this
         ├── signing.ts           fixed quote / verify / submit path
         ├── tools.ts             read-only chain tools for the LLM
-        ├── main.ts              A2A/X402 entrypoint
-        ├── mcpMain.ts           MCP-only entrypoint
-        └── dualMain.ts          combined A2A + MCP entrypoint
+        ├── unifiedMain.ts       A2A + X402 entrypoint (:9000)
+        ├── mcpMain.ts           MCP-only entrypoint (:8000/mcp)
+        └── dualMain.ts          A2A-native + tunneled /mcp (AgentCore only)
 ```
 
 Ordinary TypeScript that you own — edit, fork, or move it whenever you want.

--- a/docs/developer-kit/bnbchain-studio/quickstart.md
+++ b/docs/developer-kit/bnbchain-studio/quickstart.md
@@ -4,146 +4,135 @@ title: BNB Agent Studio Quickstart
 
 # Quickstart
 
-End-to-end path from zero to a running two-layer seller on BSC testnet. Steps 1–2 are one-time machine setup; step 3 is where you spend most of your time — talking to your AI tool, which drives `bag` for you.
+Build a TypeScript seller agent on BNB Chain, run it locally, and deploy it.
 
-## 1. Install the CLI
+## Requirements
 
-```bash
-npm install -g @bnbagent/studio-cli
-bag --version
-```
+- **Node.js 22 or newer**
+- **Claude Code or Cursor** — the bundled skill is the primary interface
+- **Corepack and pnpm 10** for the generated workspace
+- **Bun 1.3+** when you deploy
+- **Docker** only for container paths, such as a `twak` deployment
+- The AWS CLI is optional, and used only by a read-only AgentCore quota check
 
-**Prerequisite — AgentCore CLI:**
-
-```bash
-npm install -g @aws/agentcore   # Node ≥ 20
-which -a agentcore              # ensure the npm CLI wins on PATH
-```
-
-## 2. Install skills into your AI tool
-
-Skills are the playbooks your AI tool reads to know *how* to drive `bag`. Without this step, Claude Code or Cursor does not know the studio exists.
+## 1. Install Studio and its IDE skill
 
 ```bash
-bag skills install                            # interactive: detect IDE + pick scope
-bag skills install --target both --scope user  # non-interactive: both IDEs, machine-wide
+npm install --global @bnbagent/studio-cli
+bag skills install
 ```
 
-Reload your IDE window after installing. You get 10 skills (scaffolding, selling via 8183, operating, deploying to AgentCore/EC2, and more).
-
-## 3. Scaffold a seller agent
-
-Open your AI tool and describe what you want:
-
-> *"Create a new BNB agent named weather-seller on testnet that sells weather forecasts."*
-
-Under the hood, the scaffolding skill runs `bag init`:
+The npm install puts the `bag` CLI on your machine once; each agent you build later
+gets its own project directory. `bag skills install` detects Claude Code and Cursor,
+lets you choose user or project scope, and installs the `/bnbagent-studio` router plus
+its on-demand playbooks. For a scripted install:
 
 ```bash
-bag init weather-seller
-cd weather-seller
+bag skills install --target both --scope user
 ```
 
-Defaults (override with flags):
+Reload your IDE afterwards so it discovers the skill.
 
-| Setting | Default | Flag |
-|---------|---------|------|
-| Framework | Google ADK | `--framework adk` |
-| Runtime | AWS Bedrock AgentCore | `--runtime agentcore` |
-| LLM provider | Pieverse (`auto/free`, $0 deposit) | `--llm-provider pieverse-llm` |
-| Network | BSC testnet | `--network bsc-testnet` |
-| Storage | IPFS | `--storage-provider ipfs` |
+## 2. Tell the skill what you want to sell
 
-On an interactive terminal, `bag init` also:
+Open Claude Code or Cursor in the directory where the project should be created:
 
-1. Prompts once for a wallet password and creates `.studio/wallets/<address>.json` at the **workspace root** (outside `app/agent/`, so no deploy artifact can bundle it).
-2. Activates the Pieverse LLM with a **$0 deposit** (default provider).
-3. Prints testnet faucet URLs — funding is optional.
-4. Provisions per-layer virtualenvs (`app/agent/.venv`, `app/service/.venv`).
-
-Use `--no-onboard` in CI to skip prompts.
-
-### Emitted workspace layout
-
-```
-weather-seller/                    workspace root
-├── .studio/wallets/               encrypted keystore (gitignored)
-├── app/
-│   ├── agent/                     Layer A — sole signer + LLM
-│   │   ├── studio.toml
-│   │   ├── main.py
-│   │   ├── signing.py
-│   │   └── managed_model.py
-│   └── service/                   Layer B — keyless public ingress
-│       ├── studio.toml
-│       └── service.py
-└── agentcore/agentcore.json       AgentCore deploy descriptor
+```text
+/bnbagent-studio Create a BNB Chain seller agent named weatheragent.
+Start on BSC testnet, explain the available choices, then build and run it.
 ```
 
-## 4. Wire the MCP server (optional but recommended)
+You can be more specific:
 
-The read-only MCP server lets your AI tool query wallet balance, job status, and more:
+```text
+/bnbagent-studio Create an agent named researchagent that sells cited research
+reports. Use ERC-8183, expose A2A and MCP, use the default wallet and LLM, store
+deliverables on IPFS, and prepare it for the 48-hour BNB testnet trial.
+```
+
+The skill asks for the decisions it needs in one round, shows its work as a todo
+list, and routes each stage to the relevant playbook. You do not need to memorise
+the CLI.
+
+!!! important "Keep control of the consequential steps"
+    The skill prepares and runs the workflow, but leaves the decisions with you:
+
+    - approve each shell command in your IDE — **do not** grant a blanket `bag:*`
+      permission, because the CLI includes deploy and payment commands
+    - enter wallet passwords through hidden prompts or `.studio/.env.local`, never
+      in chat or as command-line arguments
+    - obtain testnet funds and decide how much value a wallet may hold
+    - review cloud permissions, runtime-secret exposure, and costs before deploying
+    - confirm on-chain transactions and buyer settlement actions
+
+## 3. Implement the work
+
+Everything the skill generates is ordinary TypeScript under `app/agent/src/`. The
+only file you normally need to edit is the `runWork` hook:
+
+```text
+app/agent/src/sellerCore.ts     ← the work your agent sells
+```
+
+Pricing and signing deliberately stay out of your way, in fixed deterministic code
+(`app/agent/src/signing.ts`). The LLM never participates in pricing and never gets a
+signing tool — its chain tools are read-only.
+
+## 4. Run and diagnose locally
 
 ```bash
-bag mcp serve --transport stdio   # 15 read-only tools; no signing
+bag doctor      # project, wallet, balances, LLM, network, local runtime
+bag dev         # start the selected faces
 ```
 
-In Claude Code or Cursor, add an MCP entry per project:
+Depending on the faces you chose, `bag dev` serves:
 
-| Field | Value |
-|-------|-------|
-| Command | `bag` |
-| Args | `mcp serve --transport stdio` |
-| CWD | absolute path to your workspace root |
-| Env | `WALLET_PASSWORD=<your password>` |
+| Face | Local surface |
+| --- | --- |
+| A2A | agent card + JSON-RPC on port `9000` |
+| MCP | Streamable HTTP at `http://localhost:8000/mcp` |
+| X402 | `/x402` on the same runtime |
 
-## 5. Run both layers locally
+## 5. Deploy
 
 ```bash
-bag dev
-# Agent on :8080 (sole signer, runs the LLM)
-# Service on :8003 (public ingress + job poller)
+bag deploy prepare                  # storage, provider and tooling readiness gates
+bag deploy --provider bnb           # or: aws | azure
+bag deploy verify --provider bnb    # reconcile ERC-8004 identity with the live endpoint
 ```
 
-Health check:
+Every deploy explicitly selects a target — a recorded deployment is only ever offered
+as an explicit update, never used as a silent default.
+
+| Target | What it is | Notes |
+| --- | --- | --- |
+| `bnb` | Managed 48-hour **testnet** trial | Runs in the operator's cloud, so signing material leaves your control. Use a throwaway wallet (`bag wallet new`) and never reuse it on mainnet. Disabled after expiry. |
+| `aws` | AWS Bedrock AgentCore in **your** account | Runtime material is injected into your own infrastructure. |
+| `azure` | Azure AI Foundry hosted agents | Container-only, delegated to the pinned deploy engine. **A2A scaffolds only** — an MCP entrypoint is rejected before deploy. |
+
+Local deliverable storage **fails deployment readiness** by design; switch to IPFS
+before deploying.
+
+## 6. Earn and settle
+
+Buyers fund ERC-8183 jobs or pay an x402 request. The agent verifies payment on-chain
+*before* doing paid work, submits the result, and records an audit trail
+(`bag audit ls`).
+
+Settlement stays with the buyer: after fetching the deliverable they choose approve,
+reject, or dispute. Studio never silently auto-settles a buyer's job. Operator-side
+settle is manual:
 
 ```bash
-curl localhost:8003/apex/health     # → {"status":"ok","keyless":true}
+bag erc8183 settle <jobId>
 ```
 
-Flags: `--agent-only`, `--service-only`, `--port`, `--service-port`.
+## Notes on the CLI
 
-## 6. Implement your service logic
+`bag --help` lists the full surface. The commands above are the ones the guided path
+uses; `bag deploy --help` covers the deploy subcommands (`prepare`, `verify`,
+`status`, `logs`, `info`, `destroy`).
 
-Edit the emitted handler in `app/agent/` — the one file you typically customize. Set your price in `app/agent/studio.toml` under `[payments.erc8183]`; the Agent clamps the LLM's proposed price to `[min, max]` before signing.
+---
 
-## 7. Deploy (when ready)
-
-```bash
-bag deploy prepare                       # readiness sweep
-bag deploy agent                         # Layer A → AgentCore
-# Layer B → EC2 via the deploying-service-to-ec2 skill
-bag deploy verify --endpoint <service-url>   # probe + register ERC-8004 endpoint
-```
-
-See [Deployment](deployment.md) for the full two-artifact path.
-
-## Natural-language workflow
-
-After setup, drive everything from your AI tool:
-
-> *"Start my agent and verify it works."*
-> *"Why isn't my Service picking up funded jobs?"*
-> *"Settle job 23."*
-> *"Deploy my agent."*
-
-The skills run the right `bag` commands and edit your files. The commands above are shown for transparency.
-
-## Next steps
-
-- [Demo](demo.md) — full end-to-end weather-forecast seller walkthrough
-- [Architecture](architecture.md) — how the six layers fit together
-- [Configuration](configuration.md) — `studio.toml` sections and env vars
-- [BNB Agent SDK quickstart](../bnbagent-sdk/quickstart.md) — protocol-level integration
-
-[← BNB Agent Studio overview](index.md)
+[← BNB Agent Studio overview](index.md) · [Configuration](configuration.md) · [Deployment](deployment.md)

--- a/docs/developer-kit/index.md
+++ b/docs/developer-kit/index.md
@@ -8,8 +8,8 @@ Index of official BNB Chain tools. Full SDK guides live in each product folder b
 
 | Product | Chains | Card |
 |---------|--------|------|
-| **BNB Agent SDK** | BSC, opBNB | [bnbagent-sdk/](bnbagent-sdk/index.md) |
 | **BNB Agent Studio** | BSC | [bnbchain-studio/](bnbchain-studio/index.md) |
+| **BNB Agent SDK** | BSC, opBNB | [bnbagent-sdk/](bnbagent-sdk/index.md) |
 | **Greenfield SDK** | Greenfield | [greenfield-sdk/](greenfield-sdk/index.md) |
 | **MCP & Ask AI** | BSC, opBNB, Greenfield (bnbchain-mcp); BSC docs (Ask AI) | [mcp/](mcp/index.md) |
 | **MPP SDK** | BSC, opBNB | [mpp-sdk/](mpp-sdk/index.md) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -285,15 +285,6 @@ nav:
           - Feature Lists: ./bnb-greenfield/roadmap/features.md
   - Developer Kit:
       - Overview: ./developer-kit/index.md
-      - BNB Agent SDK:
-          - Overview: ./developer-kit/bnbagent-sdk/index.md
-          - Quickstart: ./developer-kit/bnbagent-sdk/quickstart.md
-          - Configuration: ./developer-kit/bnbagent-sdk/configuration.md
-          - Architecture: ./developer-kit/bnbagent-sdk/architecture.md
-          - Networks & Contracts: ./developer-kit/bnbagent-sdk/networks.md
-          - Examples: ./developer-kit/bnbagent-sdk/examples.md
-          - Security: ./developer-kit/bnbagent-sdk/security.md
-          - Troubleshooting: ./developer-kit/bnbagent-sdk/troubleshooting.md
       - BNB Agent Studio:
           - Overview: ./developer-kit/bnbchain-studio/index.md
           - Quickstart: ./developer-kit/bnbchain-studio/quickstart.md
@@ -304,6 +295,15 @@ nav:
           - Deployment: ./developer-kit/bnbchain-studio/deployment.md
           - Security: ./developer-kit/bnbchain-studio/security.md
           - Troubleshooting: ./developer-kit/bnbchain-studio/troubleshooting.md
+      - BNB Agent SDK:
+          - Overview: ./developer-kit/bnbagent-sdk/index.md
+          - Quickstart: ./developer-kit/bnbagent-sdk/quickstart.md
+          - Configuration: ./developer-kit/bnbagent-sdk/configuration.md
+          - Architecture: ./developer-kit/bnbagent-sdk/architecture.md
+          - Networks & Contracts: ./developer-kit/bnbagent-sdk/networks.md
+          - Examples: ./developer-kit/bnbagent-sdk/examples.md
+          - Security: ./developer-kit/bnbagent-sdk/security.md
+          - Troubleshooting: ./developer-kit/bnbagent-sdk/troubleshooting.md
       - Greenfield SDK:
           - Overview: ./developer-kit/greenfield-sdk/index.md
       - MCP & Ask AI:


### PR DESCRIPTION
> ### 📋 Merge order
> One of four related docs PRs. Recommended sequence:
>
> | # | PR | Depends on |
> |---|---|---|
> | 1 | [#885](https://github.com/bnb-chain/bnb-chain.github.io/pull/885) — Studio Node path + nav order | — |
> | 2 | [#884](https://github.com/bnb-chain/bnb-chain.github.io/pull/884) — TypeScript SDK quickstart | **rebased on #885**; fast-forwards after it |
> | 3 | [#886](https://github.com/bnb-chain/bnb-chain.github.io/pull/886) — Studio architecture | independent |
> | 4 | [#887](https://github.com/bnb-chain/bnb-chain.github.io/pull/887) — remaining Studio pages | independent |
>
> [#882](https://github.com/bnb-chain/bnb-chain.github.io/pull/882) (SDK server-module fixes) is independent of all four.

---

## Summary

The Studio docs described a product that does not ship. This rewrites the two entry pages against the published [`@bnbagent/studio-cli@0.0.12`](https://www.npmjs.com/package/@bnbagent/studio-cli) tarball, and moves Studio to the front of the Developer Kit nav.

## `quickstart.md` — these were wrong, not merely stale

| Page said | Package actually ships |
|---|---|
| *"Framework Google ADK (`--framework adk`)"* | **Zero** trace of Google ADK anywhere — not in `package.json` deps, not in any skill or recipe file |
| Python layout: `main.py`, `signing.py`, `managed_model.py`, `service.py` | **TypeScript** scaffold — `sellerCore.ts`, `signing.ts`, `tools.ts`, `main.ts`, `mcpMain.ts`, `dualMain.ts` |
| `npm install -g @aws/agentcore  # Node ≥ 20` | **Node ≥ 22** (`engines.node`); cloud lifecycle delegated to the pinned `@bnbagent/deploy-cli`; AWS CLI **optional**, used only by a read-only quota check |

Rewritten around what ships: the skill-first workflow, the six-stage journey, the real generated tree, and the three deploy targets.

**Azure Foundry is included** — `recipes/runtimes/azure-foundry/recipe.toml` is `status = "v1"`, `bag deploy --provider azure` is real, and it deploys **A2A scaffolds only** (MCP is rejected before a Foundry deploy). Worth flagging upstream: the `studio-cli` README never mentions Azure and its deployment table says *"Every deploy asks for `bnb` or `aws`"*, which is why this was easy to miss.

## `index.md` — the two-layer model is gone

Replaced Layer A / Layer B (`app/service/` → EC2/Fargate, "keyless", "no LLM, no sign") with the shipped **one runtime, one signer**: a single process serving composable A2A (`:9000`) / MCP (`:8000/mcp`) / X402 (`/x402`) faces, holding the only key, signing in fixed code at `app/agent/src/signing.ts`.

Also:
- dropped *"v0.0.1 is seller-only … Buyer product flows … deferred to v2"*
- replaced Python package names (`bnbagent_studio_core`) with `@bnbagent/studio-runtime` and `@bnbagent/deploy-cli`
- added an explicit **Studio vs SDK** table — "a library you import" vs "a tool that builds and deploys an app for you" — since conflating the two is the most common source of confusion
- documented that local deliverable storage **fails deployment readiness** by design, and that Studio never auto-settles a buyer's job

## Nav

Developer Kit now leads with **BNB Agent Studio**, ahead of the SDK, matching the agentic-first ordering the marketing site already uses. The developer-kit landing table is reordered to match.

```
Developer Kit
  ├── Overview
  ├── BNB Agent Studio     ← moved up
  ├── BNB Agent SDK
  ├── Greenfield SDK
  └── …
```

## Verification

- `mkdocs.yml` parses; all **33** `developer-kit` nav paths resolve
- every relative link in both rewritten pages resolves
- grep for `Google ADK|--framework adk|main.py|managed_model.py|@aws/agentcore|Node ≥ 20|Layer A|Layer B|keyless|EC2|Fargate|bnbagent_studio_core|seller-only|deferred to v2` across both pages returns only one deliberate hit: the sentence *"There is **no** separate keyless service tier."*

## Not in this PR

`bnbchain-studio/architecture.md` still documents the Layer A / Layer B model in full (diagram, `app/service/service.py`, keyless boundary invariants) and needs the same treatment. Kept separate to stay reviewable.