### PR TITLE
docs(studio): finish the Node path across the remaining pages

### DIFF
--- a/docs/developer-kit/bnbchain-studio/cli-reference.md
+++ b/docs/developer-kit/bnbchain-studio/cli-reference.md
@@ -10,7 +10,7 @@ The `bag` CLI exposes 19 command groups. Run `bag --help` or `bag <group> --help
 
 | Group | Purpose | Key subcommands |
 |-------|---------|-----------------|
-| `init` | Scaffold a two-layer workspace | `bag init <name> [--framework adk] [--runtime agentcore] [--llm-provider pieverse-llm] [--network bsc-testnet] [--no-onboard] [--ide claude-code\|cursor\|both]` |
+| `init` | Scaffold a seller agent workspace | `bag init <name> [--runtime agentcore\|azure-foundry] [--llm-provider pieverse-llm] [--network bsc-testnet] [--wallet-kind evm-local\|twak\|altana] [--protocols A2A,MCP,X402] [--storage-provider local\|ipfs] [--no-onboard] [--ide claude-code\|cursor\|both]` |
 | `scan` | Detect project type + manifest | `bag scan` |
 | `recipe` | Print recipe code/files | `list` / `show` / `code` |
 | `skills` | Install IDE skills | `list` / `install --target {claude-code,cursor,both}` / `uninstall` |

--- a/docs/developer-kit/bnbchain-studio/cli-reference.md
+++ b/docs/developer-kit/bnbchain-studio/cli-reference.md
@@ -43,7 +43,7 @@ bag llm status --full
 ### Register on-chain identity
 
 ```bash
-bag erc8004 register --endpoint https://my-service.example.com/apex/
+bag erc8004 register --endpoint https://my-agent.example.com
 bag erc8004 show
 ```
 
@@ -66,9 +66,8 @@ bag doctor
 
 ```bash
 bag deploy prepare
-bag deploy prepare --include-service-preflight   # opt-in EC2 IAM simulation
 bag deploy agent
-bag deploy package                               # Layer B zip → dist/
+bag deploy package                               # build the deploy artifact → dist/
 bag deploy verify --endpoint https://my-service.example.com
 bag deploy status
 ```
@@ -99,17 +98,9 @@ Cross-layer commands (`doctor`, `scan`, `erc8004 register`) operate on whichever
 
 AgentCore runtime names must match `^[A-Za-z][A-Za-z0-9]{0,22}$` (no `-`, `_`, `.`). `bag doctor` validates `agentcore/agentcore.json` names and fails on violations.
 
-## Flat imports in emitted code
-
-Emitted `app/agent/` and `app/service/` use **flat** (top-level) imports because AgentCore runs `main.py` as a top-level module:
-
-```python
-from managed_model import X      # correct
-from .managed_model import X     # wrong — bag doctor warns
-```
-
 ## Further reference
 
-Full capability reference: [GitHub — reference.md](https://github.com/bnb-chain/bnbagent-studio/blob/main/docs/reference.md)
+`bag --help` and `bag <group> --help` are the authoritative surface for the installed
+version.
 
 [← BNB Agent Studio overview](index.md)

--- a/docs/developer-kit/bnbchain-studio/configuration.md
+++ b/docs/developer-kit/bnbchain-studio/configuration.md
@@ -13,11 +13,11 @@ BNB Agent Studio projects use two config files per layer plus environment variab
 | File | Sections |
 |------|----------|
 | `app/agent/studio.toml` | `[stack]`, `[wallet]`, `[llm.*]`, `[budget]`, `[payments.erc8183]`, `[payments.x402]`, `[network]`, `[storage]`, `[identity]`, `[deploy]` |
-| `app/service/studio.toml` | `[network]`, `[agent]`, `[deploy]`, `[storage]`, `[provider]`, `[payments.erc8183]` |
 
-### Cross-layer sync
+One runtime means one `studio.toml`. Earlier versions emitted a second config for a
+separate keyless service; that tier no longer exists.
 
-Only two values legitimately live in **both** files:
+### Shared values
 
 | Field | Agent | Service | Sync mechanism |
 |-------|-------|---------|----------------|
@@ -47,11 +47,11 @@ max_price = "1000000000000000000"
 default = "bsc-testnet"
 ```
 
-### Key service sections
+### Deploy and rail sections
 
 ```toml
 [agent]
-runtime_arn = ""   # filled after Layer A deploy
+runtime_arn = ""   # filled after deploy
 
 [payments.erc8183]
 poll_interval_seconds = 30
@@ -61,7 +61,7 @@ auto_settle = true
 # address synced from wallet via bag wallet new
 ```
 
-Use `bag config show`, `bag config get <key>`, and `bag config set <key> <value>` for CRUD. From workspace root, pass `--project-root app/agent` or `--project-root app/service`.
+Use `bag config show`, `bag config get <key>`, and `bag config set <key> <value>` for CRUD. From workspace root, pass `--project-root app/agent`.
 
 ## Environment variables
 
@@ -79,11 +79,9 @@ Use `bag config show`, `bag config get <key>`, and `bag config set <key> <value>
 | `STORAGE_IPFS_GATEWAY` | Deploy | IPFS gateway for deliverables |
 | `STUDIO_AGENT_LOCAL_URL` | Service-only dev | Agent URL when running `bag dev --service-only` |
 
-### Service (`app/service/.env.local`)
+### Deploy-time secrets
 
-The Service is keyless — **no wallet secrets**. It may read runtime connection vars injected at deploy time. `bag deploy package` **never** includes any `.env*` in the Service zip.
-
-### Deploy-time secrets (Layer A)
+`bag deploy package` **never** includes any `.env*` file in a deploy artifact.
 
 | Mode | Keystore delivery |
 |------|-------------------|

--- a/docs/developer-kit/bnbchain-studio/demo.md
+++ b/docs/developer-kit/bnbchain-studio/demo.md
@@ -4,9 +4,22 @@ title: BNB Agent Studio Demo
 
 # Demo — weather-forecast seller (end to end)
 
-This walkthrough follows the full BNB Agent Studio path for a single example: a **weather-forecast seller** on BSC testnet. You install the CLI, scaffold the agent with your AI IDE, set up a wallet, fund it, activate an LLM, run locally, negotiate a sale, register on-chain, and deploy.
+!!! danger "This walkthrough is out of date — use the Quickstart instead"
+    This page still documents the earlier **Python, two-layer** Studio (Layer A Agent +
+    Layer B keyless Service, `main.py` / `service.py`, `npm i -g @aws/agentcore`). The
+    shipped product is a **TypeScript, single-runtime** tool: see
+    **[Quickstart](quickstart.md)** and [Architecture](architecture.md) for the current
+    flow.
 
-Commands and behavior match the [bnbagent-studio](https://github.com/bnb-chain/bnbagent-studio) repository — see the [weather seller example](https://github.com/bnb-chain/bnbagent-studio#-example-a-weather-forecast-seller-end-to-end) in the README for the canonical reference.
+    It has not been rewritten because a faithful end-to-end walkthrough has to be
+    *executed* to be trustworthy — every command output, wallet prompt, and deploy
+    result verified against a real run — rather than adapted on paper. Rewriting it from
+    inference would produce a confident-looking guide that does not work, which is worse
+    than an openly flagged stale one.
+
+    Kept for now only as a record of the earlier flow's shape.
+
+This walkthrough follows the full BNB Agent Studio path for a single example: a **weather-forecast seller** on BSC testnet. You install the CLI, scaffold the agent with your AI IDE, set up a wallet, fund it, activate an LLM, run locally, negotiate a sale, register on-chain, and deploy.
 
 ## Prerequisites
 
@@ -431,7 +444,7 @@ $ cd ~/Desktop/weather-seller/app/agent && set -a && . ./.env.local && set +a &&
   | description | Weather forecasts on demand — paid via ERC-8183                                |
   | protocol    | ERC8183                                                                        |
   | endpoint    | http://localhost:8003/apex/ (update after deploy)                              |
-  | registry    | See [Networks & contracts](../../bnbagent-sdk/networks.md) for deployment refs |
+  | registry    | See [Networks & contracts](../bnbagent-sdk/networks.md) for deployment refs |
 
   Remaining items
 

--- a/docs/developer-kit/bnbchain-studio/deployment.md
+++ b/docs/developer-kit/bnbchain-studio/deployment.md
@@ -4,124 +4,122 @@ title: BNB Agent Studio Deployment
 
 # Deployment
 
-A v1 seller deploys as **two artifacts** — Layer A (Agent) to AWS Bedrock AgentCore, Layer B (Service) to EC2/Fargate. Use the bundled IDE skills (`bnbagent-studio-use-aws-agentcore`, `bnbagent-studio-deploying-service-to-ec2`) for guided deploys, or run the commands below directly.
+A Studio project deploys as **one runtime** — the same process that holds the key and
+serves your selected faces. There is no second keyless artifact to ship.
 
-On-chain deployments: [apex-contracts#deployments](https://github.com/bnb-chain/apex-contracts#deployments).
+Every deploy **explicitly selects a target**. A recorded deployment is only ever offered
+as an explicit update; it is never used as a silent default.
+
+All cloud lifecycle mutations are delegated to the pinned
+[`@bnbagent/deploy-cli`](https://www.npmjs.com/package/@bnbagent/deploy-cli). Studio does
+not shell out to `azd` or the Azure CLI, and the scaffold contains no `azure.yaml` or
+`infra/`.
+
+!!! warning "You are provisioning real resources"
+    AWS and Azure deploys create resources in **your own** account, under permissions you
+    review. Published IAM reference policies are provided as-is — scoping, costs, and
+    security remain yours. Start on BSC testnet.
+
+## The three targets
+
+| Target | What it is | Key constraint |
+| --- | --- | --- |
+| `bnb` | Managed **48-hour testnet** trial | Runs in the **operator's** cloud, so signing material leaves your control. Use a throwaway wallet (`bag wallet new`) and never reuse it on mainnet. Disabled after expiry. |
+| `aws` | AWS Bedrock AgentCore in your account | Keystore injected via **AWS Secrets Manager** as `WALLET_KEYSTORE_JSON` — never in the code zip. |
+| `azure` | Azure AI Foundry hosted agents | **Container-only**, and **A2A scaffolds only** — `bag init` and provider selection reject an MCP entrypoint for Foundry. Secrets injected through a Foundry **CustomKeys** connection. |
 
 ## Prerequisites
 
-| Requirement | Notes |
-|-------------|-------|
-| AgentCore CLI | `npm i -g @aws/agentcore` (Node ≥ 20) |
-| AWS account | You provision resources in your own account under IAM policies you review |
-| `agentcore configure` | One-time setup — writes `agentcore/agentcore.json` |
-| IAM policies | Reference configs: [least-privilege guide](https://github.com/bnb-chain/bnbagent-studio/blob/main/docs/guides/least-privilege-iam.md), [policy JSON](https://github.com/bnb-chain/bnbagent-studio/blob/main/docs/guides/iam-policies.md) |
-
-> Deploying provisions AWS resources in your account. Review [DISCLAIMER.md](https://github.com/bnb-chain/bnbagent-studio/blob/main/DISCLAIMER.md) before first deploy.
+| Requirement | Needed for |
+| --- | --- |
+| Node.js ≥ 22 | everything |
+| Bun 1.3+ | any deploy |
+| Corepack + pnpm 10 | the generated workspace |
+| Docker | container paths only — for example a `twak` deployment, and Azure (container-only) |
+| AWS CLI | **optional**; used only by the fail-open, read-only AgentCore quota check in `bag deploy prepare` |
 
 ## Deploy flow
 
 ```bash
-bag deploy prepare                       # readiness sweep (BLOCKED/CRITICAL/WARNING)
-bag deploy agent                         # Layer A → AgentCore
-bag deploy package                       # Layer B zip → dist/<name>-service-<sha>.zip
-# upload + systemd on EC2 (see deploying-service-to-ec2 skill)
-bag deploy verify --endpoint <public-url>   # probe layers + register ERC-8004 endpoint
-bag deploy status                        # dashboard: liveness, inventory, cost estimate
+bag deploy prepare                    # readiness gates: storage, provider, tooling
+bag deploy --provider bnb             # or: aws | azure
+bag deploy verify --provider bnb      # reconcile ERC-8004 identity with the live endpoint
+bag deploy status --provider bnb      # liveness and inventory
 ```
 
-## Layer A — Agent (AgentCore)
+`bag deploy prepare` gates on storage, provider, and deploy-tooling readiness. **Local
+deliverable storage fails readiness by design** — switch to IPFS before deploying, since
+a local path is unreachable from a deployed runtime.
+
+For AWS, an inbound-auth step may be required before the first deploy:
 
 ```bash
-bag deploy agent
+bag deploy provision-cognito
 ```
 
-- Thin-wraps `agentcore deploy` (run `agentcore configure` first)
-- Default `--secrets-mode secretsmanager` pushes keystore to AWS Secrets Manager as `WALLET_KEYSTORE_JSON` — **never** in the CodeZip
-- Testnet-only `--secrets-mode envvars` inlines secrets in `agentcore.json` — refused on mainnet
-- First deploy gates on explicit IAM risk acceptance (interactive or `--accept-risk`)
-- Records `runtime_arn` in `app/service/studio.toml` `[agent]` section
-
-**Multi-environment:** pass agentcore's `--target` through: `bag deploy agent -- --target prod`. Studio records one target per workspace — deploying multiple targets overwrites recorded state.
-
-**Redeploy:** every `bag deploy agent` re-runs `agentcore deploy` (CDK). First run is slow (~4–6 min); subsequent runs use cache.
-
-### Keystore posture
-
-The encrypted keystore lives at workspace root `.studio/wallets/`, **outside** `app/agent/` (the AgentCore codeLocation). No packaging path — including a raw `agentcore deploy` — can bundle it. At deploy, it is injected via Secrets Manager.
-
-## Layer B — Service (EC2)
+## Operating a deployment
 
 ```bash
-bag deploy package
+bag deploy status  --provider aws     # liveness + resource inventory
+bag deploy logs    --provider aws     # tail runtime logs
+bag deploy info    --provider azure   # resolved deployment details
+bag deploy destroy --provider aws     # teardown
 ```
 
-Produces a zip rooted at `app/service/` (so `service.py` is at zip top level) plus a `.sha256` sidecar. Excludes:
+`bag deploy --help` lists the full surface. `bag deploy agent` remains available as the
+agent-scoped form.
 
-- `.venv/`, `__pycache__/`, `.git/`, `.studio/`, `dist/`
-- **All `.env*`** — the keyless host must not receive Agent secrets
+## Keystore posture
 
-Hand the zip to the EC2 deploy skill. The Service reads the Agent runtime ARN from `app/service/studio.toml` `[agent].runtime_arn` and calls `InvokeAgentRuntime` for every signing operation.
+The encrypted keystore lives at the workspace root in `.studio/wallets/`, **outside**
+`app/agent/` — the deploy `codeLocation`. No packaging path can bundle it into an
+artifact. It reaches a deployed runtime only through the selected provider's delegated
+secret channel:
 
-**Fast redeploy:** Layer B supports code-only updates — `scp` + `systemctl restart` without full reprovision.
+| Target | Channel |
+| --- | --- |
+| `aws` | AWS Secrets Manager (`WALLET_KEYSTORE_JSON`) |
+| `azure` | Foundry CustomKeys connection |
+| `bnb` | the operator's managed secret store — material leaves your control |
 
-## Readiness checks
-
-`bag deploy prepare` runs checks including:
-
-- `studio.toml` parseable on both layers
-- AgentCore runtime name valid
-- Flat imports (no package-relative imports in emitted code)
-- Network and provider address sync between layers
-- Legacy keystore inside `app/agent/` (warn only)
-
-Opt-in cross-layer check:
-
-```bash
-bag deploy prepare --include-service-preflight
-```
-
-Simulates Layer B EC2 provisioning IAM actions via `iam:SimulatePrincipalPolicy` — surfaces permission issues before Agent deploy completes.
-
-## Post-deploy verification
-
-```bash
-bag deploy verify --endpoint https://my-service.example.com
-```
-
-- Probes Layer A liveness via AgentCore
-- Probes Layer B `/apex/health`
-- Registers the Service public URL as the ERC-8004 endpoint
-
-## Operations
-
-```bash
-bag deploy status              # liveness + resource inventory + cost estimate
-bag deploy status --no-probe   # skip HTTP probes
-bag deploy logs --layer agent  # CloudWatch tail
-bag deploy logs --layer service  # SSH + journalctl
-bag deploy destroy             # dry-run teardown plan; --execute for Layer A only
-```
-
-`bag deploy destroy` prints Layer B teardown as `aws` CLI commands but **never** executes them — you run those manually.
+An **Altana** deployment is different in kind: it sends only a budget- and time-bounded
+runtime session rather than a keystore. Keep the budget and expiry tight, and renew or
+revoke explicitly.
 
 ## ERC-8004 registration
 
-After deploy, buyers discover your agent via ERC-8004. `bag deploy verify` registers the endpoint, or run manually:
+Buyers discover your agent on-chain. `bag deploy verify --provider <target>` reconciles
+the deployed endpoint with its ERC-8004 identity. The registry commands are also
+available directly:
 
 ```bash
-bag erc8004 register --endpoint https://my-service.example.com/apex/
 bag erc8004 show
 ```
 
 ## Local mirror
 
-`bag dev` is the local mirror of the two-artifact deploy:
+`bag dev` runs the same single runtime locally:
 
 | Local | Deployed |
-|-------|----------|
-| Agent `:8080` | AgentCore runtime |
-| Service `:8003` | EC2 `/apex/*` |
-| `STORAGE_LOCAL_PATH` | S3 / IPFS |
+| --- | --- |
+| A2A on `:9000` | the runtime's A2A face |
+| MCP on `:8000/mcp` | the runtime's MCP face (not available on Azure) |
+| `/x402` on the same process | the runtime's x402 face |
+| local storage path | IPFS |
 
-[← BNB Agent Studio overview](index.md)
+## Earning after deploy
+
+Buyers fund ERC-8183 jobs or pay an x402 request. The runtime verifies payment on-chain
+*before* doing paid work, submits the deliverable, and records an audit trail
+(`bag audit ls`).
+
+Settlement stays with the buyer, who chooses approve, reject, or dispute. Operator-side
+settle is manual:
+
+```bash
+bag erc8183 settle <jobId>
+```
+
+---
+
+[← BNB Agent Studio overview](index.md) · [Architecture](architecture.md) · [Security](security.md)

--- a/docs/developer-kit/bnbchain-studio/troubleshooting.md
+++ b/docs/developer-kit/bnbchain-studio/troubleshooting.md
@@ -14,11 +14,11 @@ bag doctor
 
 ### `bag doctor` reports network drift
 
-`[network].default` must agree between `app/agent/studio.toml` and `app/service/studio.toml`.
+`[network].default` in `app/agent/studio.toml` must match the network your wallet and
+deploy target expect.
 
 ```bash
 bag config set network.default bsc-testnet --project-root app/agent
-# mirrors to service automatically
 ```
 
 ### Provider address mismatch
@@ -30,37 +30,30 @@ bag wallet show
 bag doctor   # re-check sync
 ```
 
-### Package-relative imports
+### Generated code will not build
 
-AgentCore runs `main.py` as a top-level module. Use flat imports:
-
-```python
-from signing import quote    # correct
-from .signing import quote   # wrong
-```
-
-`bag doctor` warns on remaining package-relative imports.
+The generated project is a pnpm workspace. Make sure Corepack and pnpm 10 are active,
+then reinstall from the workspace root before re-running `bag dev`.
 
 ### AgentCore runtime name invalid
 
 Runtime names must match `^[A-Za-z][A-Za-z0-9]{0,22}$`. No hyphens, underscores, or dots. Re-run `agentcore configure` with a valid name if `bag doctor` fails.
 
-### `agentcore` not found or wrong binary
+### Wrong Node version
 
 ```bash
-which -a agentcore
-node --version    # must be ≥ 20
-npm install -g @aws/agentcore
+node --version    # must be >= 22
 ```
 
-Ensure the npm CLI wins on PATH over any Python shim.
+The AWS CLI is **not** required to deploy — it is used only by the fail-open, read-only
+AgentCore quota check in `bag deploy prepare`.
 
-### Service not picking up funded jobs
+### Funded jobs are not being picked up
 
-1. Confirm both layers are running: `bag dev` or deployed equivalents
-2. Check `app/service/studio.toml` `[agent].runtime_arn` is set after Layer A deploy
-3. Verify `[payments.erc8183].poll_interval_seconds` and `auto_settle`
-4. Probe health: `curl <service-url>/apex/health`
+1. Confirm the runtime is up: `bag dev`, or `bag deploy status --provider <target>`
+2. Verify `[payments.erc8183]` in `app/agent/studio.toml`
+3. Probe the runtime: `curl <endpoint>/readiness`
+4. Remember `settle` is manual — `bag erc8183 settle <jobId>`
 
 ### `PolicyViolation` / `X402PolicyError` at runtime
 


### PR DESCRIPTION
> ### 📋 Merge order
> This is the **last** of four stacked/related docs PRs. Recommended sequence:
>
> | # | PR | Depends on |
> |---|---|---|
> | 1 | [#885](https://github.com/bnb-chain/bnb-chain.github.io/pull/885) — Studio Node path + nav order | — |
> | 2 | [#884](https://github.com/bnb-chain/bnb-chain.github.io/pull/884) — TypeScript SDK quickstart | **rebased on #885**; fast-forwards after it |
> | 3 | [#886](https://github.com/bnb-chain/bnb-chain.github.io/pull/886) — Studio architecture | independent |
> | 4 | **this PR** — remaining Studio pages | independent |
>
> [#882](https://github.com/bnb-chain/bnb-chain.github.io/pull/882) (SDK server-module fixes) is independent of all four.

## Summary

Completes the Studio Node-path sweep from #885 and #886. Verified against the published [`@bnbagent/studio-cli@0.0.12`](https://www.npmjs.com/package/@bnbagent/studio-cli) tarball.

## `deployment.md` — rewritten

The page described shipping **two artifacts**: Layer A to AgentCore, Layer B to EC2/Fargate, via `bag deploy agent` + `bag deploy package` + a manual EC2 upload. One runtime ships now, and every deploy explicitly selects `bnb | aws | azure`.

Now documents the real per-target constraints and secret channels:

| Target | Constraint | Secret channel |
|---|---|---|
| `bnb` | 48h testnet trial, runs in the **operator's** cloud — signing material leaves your control | operator's managed store |
| `aws` | AgentCore in your account | AWS Secrets Manager (`WALLET_KEYSTORE_JSON`) |
| `azure` | **Container-only** and **A2A-only** — an MCP entrypoint is rejected | Foundry **CustomKeys** connection |

Also: local deliverable storage **fails readiness by design**, and cloud lifecycle is delegated to the pinned `@bnbagent/deploy-cli` — no `azd`, no `azure.yaml` in the scaffold.

## Targeted fixes

**`configuration.md`** — dropped the second `app/service/studio.toml` and the keyless-Service env section. One runtime means one `studio.toml`; `--project-root app/service` no longer exists.

**`cli-reference.md`** — removed `bag deploy prepare --include-service-preflight` (**absent from the shipped CLI**) and the Python flat-imports section. Fixed `bag erc8004 register --endpoint .../apex/` — **no `apex` route exists in the package**; the runtime serves `/readiness`, `/invocations`, `/responses`, `/mcp`, `/x402`.

**`troubleshooting.md`** — replaced the two-`studio.toml` drift check, the `main.py` flat-import advice, and the `@aws/agentcore` + Node ≥ 20 prerequisite. Retargeted the funded-jobs checklist at the single runtime and `/readiness`, and noted settle is manual.

## `demo.md` — deliberately **not** rewritten

It is a 610-line walkthrough built from recorded IDE transcripts and real command output. A faithful version has to be *executed* to be trustworthy — every prompt, output, and deploy result verified against a live run with a funded wallet and cloud accounts. Adapting it on paper would produce a confident-looking guide that does not work, which is strictly worse than an openly flagged stale one.

Added a prominent banner pointing at the current Quickstart and Architecture, and stated plainly why it is kept as-is.

**Suggested follow-up:** someone with a funded testnet wallet re-runs the walkthrough and captures fresh output — that is a recording task, not an editing one.

Also fixed a **pre-existing broken link** in that page: `../../bnbagent-sdk/networks.md` was one level too deep.

## Verification

- the four rewritten pages contain **zero** stale markers (`Layer A|Layer B|EC2|Fargate|app/service|apex/|main.py|managed_model|bnbagent_studio_core|@aws/agentcore|include-service-preflight`)
- **all 37** relative links across the whole studio doc set resolve
- every command and flag checked for presence in the shipped `dist/` before being kept or removed