### PR TITLE
docs: add BoltRPC as BSC RPC provider

### DIFF
--- a/docs/bnb-smart-chain/developers/json_rpc/json-rpc-endpoint.md
+++ b/docs/bnb-smart-chain/developers/json_rpc/json-rpc-endpoint.md
@@ -64,6 +64,8 @@ You could find more endpoints from **[here](https://chainlist.org/chain/56)**.
 
 * **Blockmachine:** <https://blockmachine.io/bnb-chain-rpc>
 
+* **BoltRPC:** <https://boltrpc.io/networks/bnb>
+
 ### Starting HTTP JSON-RPC
 
 You can start the HTTP JSON-RPC with the --http flag


### PR DESCRIPTION
## Summary

- Add BoltRPC to the BSC RPC Providers list on the JSON-RPC endpoint docs
- BoltRPC provides HTTPS + WebSocket JSON-RPC for BNB Smart Chain (chain ID 56)

## Links

- Provider / product: https://boltrpc.io
- BNB Chain endpoint docs: https://boltrpc.io/networks/bnb
- API docs: https://boltrpc.io/docs

## Notes

- Endpoints require an API key (same model as other listed providers such as QuickNode / Alchemy)
- No keyless public dataseed URL is being added in this PR

## Test plan

- [ ] Confirm the BoltRPC provider bullet renders on the JSON-RPC endpoint page after merge
- [ ] Confirm https://boltrpc.io/networks/bnb loads and documents BSC (chain ID 56)