### PR TITLE
docs: add node101 as BSC RPC provider

### DIFF
--- a/docs/bnb-smart-chain/developers/json_rpc/json-rpc-endpoint.md
+++ b/docs/bnb-smart-chain/developers/json_rpc/json-rpc-endpoint.md
@@ -64,6 +64,8 @@ You could find more endpoints from **[here](https://chainlist.org/chain/56)**.
 
 * **Blockmachine:** <https://blockmachine.io/bnb-chain-rpc>
 
+* **node101:** <https://node101.io/en/rpc/bsc>
+
 ### Starting HTTP JSON-RPC
 
 You can start the HTTP JSON-RPC with the --http flag


### PR DESCRIPTION
## Summary

- Add node101 to the BNB Smart Chain RPC Providers list.
- Link to node101's BNB Smart Chain RPC service page.

## Notes

- This is a provider-directory entry only.
- No public endpoint, API key, credential, pricing, or unsupported network claim is added.

## Validation

- Confirmed the linked page documents node101's BNB Smart Chain RPC service.
- Confirmed the change follows the existing provider-list format in `json-rpc-endpoint.md`.